### PR TITLE
ShellType for Surfaceproeprties, Issue123

### DIFF
--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -90,10 +90,12 @@
     <Compile Include="Modify\SetAutoLengthOffset.cs" />
     <Compile Include="Modify\SetDiaphragm.cs" />
     <Compile Include="Modify\SetInsertionPoint.cs" />
+    <Compile Include="Modify\SetShellType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\AutoLengthOffset.cs" />
     <Compile Include="Query\Diaphragm.cs" />
     <Compile Include="Query\DiaphragmType.cs" />
+    <Compile Include="Query\EtabsShellType.cs" />
     <Compile Include="Query\InsertionPoint.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ETABS_Engine/Modify/SetShellType.cs
+++ b/ETABS_Engine/Modify/SetShellType.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Structure.Properties.Surface;
+using BH.oM.Adapters.ETABS;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static ISurfaceProperty SetShellType(this ISurfaceProperty property, ShellType shellType)
+        {
+            ISurfaceProperty clone = (ISurfaceProperty)property.GetShallowClone();
+
+            clone.CustomData["ShellType"] = shellType;
+
+            return clone;
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Query/EtabsShellType.cs
+++ b/ETABS_Engine/Query/EtabsShellType.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Structure.Properties.Surface;
+using BH.oM.Adapters.ETABS;
+using ETABS2016;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Query
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static eShellType EtabsShellType(this ISurfaceProperty panel)
+        {
+            object obj;
+
+            if (panel.CustomData.TryGetValue("ShellType", out obj) && obj is ShellType)
+            {
+                switch ((ShellType)obj)
+                {
+                    case ShellType.ShellThin:
+                        return eShellType.ShellThin;
+                    case ShellType.ShellThick:
+                        return eShellType.ShellThick;
+                    case ShellType.Membrane:
+                        return eShellType.Membrane;
+                }
+            }
+            return eShellType.ShellThin;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Elements\Diaphragm.cs" />
     <Compile Include="Enums\BarInsertionPoint.cs" />
     <Compile Include="Enums\Diaphragm.cs" />
+    <Compile Include="Enums\ShellType.cs" />
     <Compile Include="Loads\MassSource.cs" />
     <Compile Include="Loads\ModalCase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ETABS_oM/Enums/ShellType.cs
+++ b/ETABS_oM/Enums/ShellType.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.Adapters.ETABS
+{
+    public enum ShellType
+    {
+        ShellThin,
+        ShellThick,
+        Membrane
+    }
+}

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -252,31 +252,32 @@ namespace BH.Adapter.ETABS
 
             string propertyName = property2d.Name;// property2d.CustomData[AdapterId].ToString();
 
+            ETABS2016.eShellType shellType = property2d.EtabsShellType();
 
             if (property2d.GetType() == typeof(Waffle))
             {
                 Waffle waffleProperty = (Waffle)property2d;
+                m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Waffle, shellType, property2d.Material.Name, waffleProperty.Thickness);
                 retA = m_model.PropArea.SetSlabWaffle(propertyName, waffleProperty.TotalDepthX, waffleProperty.Thickness, waffleProperty.StemWidthX, waffleProperty.StemWidthX, waffleProperty.SpacingX, waffleProperty.SpacingY);
             }
-
-            if (property2d.GetType() == typeof(Ribbed))
+            else if (property2d.GetType() == typeof(Ribbed))
             {
                 Ribbed ribbedProperty = (Ribbed)property2d;
+                m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Ribbed, shellType, property2d.Material.Name, ribbedProperty.Thickness);
                 retA = m_model.PropArea.SetSlabRibbed(propertyName, ribbedProperty.TotalDepth, ribbedProperty.Thickness, ribbedProperty.StemWidth, ribbedProperty.StemWidth, ribbedProperty.Spacing, (int)ribbedProperty.Direction);
             }
-
-            if (property2d.GetType() == typeof(LoadingPanelProperty))
+            else if (property2d.GetType() == typeof(LoadingPanelProperty))
             {
-                retA = m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Slab, ETABS2016.eShellType.ShellThin, property2d.Material.Name, 0);
+                retA = m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Slab, shellType, property2d.Material.Name, 0);
             }
 
-            if (property2d.GetType() == typeof(ConstantThickness))
+            else if (property2d.GetType() == typeof(ConstantThickness))
             {
                 ConstantThickness constantThickness = (ConstantThickness)property2d;
                 if (constantThickness.PanelType == PanelType.Wall)
-                    retA = m_model.PropArea.SetWall(propertyName, ETABS2016.eWallPropType.Specified, ETABS2016.eShellType.ShellThin, property2d.Material.Name, constantThickness.Thickness);
+                    retA = m_model.PropArea.SetWall(propertyName, ETABS2016.eWallPropType.Specified, shellType, property2d.Material.Name, constantThickness.Thickness);
                 else
-                    retA = m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Slab, ETABS2016.eShellType.ShellThin, property2d.Material.Name, constantThickness.Thickness);
+                    retA = m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Slab, shellType, property2d.Material.Name, constantThickness.Thickness);
             }
 
 
@@ -317,6 +318,7 @@ namespace BH.Adapter.ETABS
             }
 
             retA = m_model.AreaObj.AddByCoord(segmentCount, ref x, ref y, ref z, ref name, propertyName);
+
             if (retA != 0)
                 return false;
 

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -316,7 +316,8 @@ namespace BH.Adapter.ETABS
                     panelConstant.Material = ReadMaterials(new List<string>() { material })[0];
                     panelConstant.Thickness = thickness;
                     panelConstant.PanelType = PanelType.Wall;
-                    if(hasModifiers)
+                    SetShellType(panelConstant, shellType);
+                    if (hasModifiers)
                         panelConstant.CustomData.Add("Modifiers", modifiers);
 
                     propertyList.Add(panelConstant);
@@ -338,6 +339,7 @@ namespace BH.Adapter.ETABS
                             panelRibbed.Spacing = ribSpacing;
                             panelRibbed.StemWidth = stemWidthTop;
                             panelRibbed.TotalDepth = depth;
+                            SetShellType(panelRibbed, shellType);
                             if (hasModifiers)
                                 panelRibbed.CustomData.Add("Modifiers", modifiers);
 
@@ -358,6 +360,7 @@ namespace BH.Adapter.ETABS
                             panelWaffle.TotalDepthX = depth;
                             panelWaffle.TotalDepthY = depth; // ETABS does not appear to to support direction dependent depth
                             panelWaffle.PanelType = PanelType.Slab;
+                            SetShellType(panelWaffle, shellType);
                             if (hasModifiers)
                                 panelWaffle.CustomData.Add("Modifiers", modifiers);
 
@@ -374,6 +377,7 @@ namespace BH.Adapter.ETABS
                             panelConstant.Thickness = thickness;
                             panelConstant.Name = id;
                             panelConstant.PanelType = PanelType.Slab;
+                            SetShellType(panelConstant, shellType);
                             if (hasModifiers)
                                 panelConstant.CustomData.Add("Modifiers", modifiers);
 
@@ -384,6 +388,24 @@ namespace BH.Adapter.ETABS
             }
 
             return propertyList;
+        }
+
+        /***************************************************/
+
+        private void SetShellType(ISurfaceProperty prop, eShellType eShellType)
+        {
+            switch (eShellType)
+            {
+                case eShellType.ShellThin:
+                    prop.CustomData["ShellType"] = oM.Adapters.ETABS.ShellType.ShellThin;
+                    break;
+                case eShellType.ShellThick:
+                    prop.CustomData["ShellType"] = oM.Adapters.ETABS.ShellType.ShellThick;
+                    break;
+                case eShellType.Membrane:
+                    prop.CustomData["ShellType"] = oM.Adapters.ETABS.ShellType.Membrane;
+                    break;
+            }
         }
 
         /***************************************************/

--- a/Etabs_Adapter/Helpers/Material.cs
+++ b/Etabs_Adapter/Helpers/Material.cs
@@ -108,7 +108,7 @@ namespace BH.Adapter.ETABS
                 model.PropMaterial.AddMaterial(ref name, GetMaterialType(material.Type), "", "", "");
                 model.PropMaterial.ChangeName(name, material.Name);
                 model.PropMaterial.SetMPIsotropic(material.Name, material.YoungsModulus, material.PoissonsRatio, material.CoeffThermalExpansion);
-                model.PropMaterial.SetWeightAndMass(material.Name, 0, material.Density);
+                model.PropMaterial.SetWeightAndMass(material.Name, 2, material.Density);
                 //modelData.materialDict.Add(material.Name, material);
 
             


### PR DESCRIPTION
Fixes #123

Set get get shell type for surface proeprties.

Test file here:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Etabs_Toolkit-Issue123-ShellTypeForSurfaceProps?csf=1&e=x0e6jJ

Fixes #125, see below.