### PR TITLE
ETABS_Toolkit Issue#128

### DIFF
--- a/ETABS_Engine/Create/Peir.cs
+++ b/ETABS_Engine/Create/Peir.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Pier Pier(string name)
+        {
+            return new Pier { Name = name};
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Create/Spandrel.cs
+++ b/ETABS_Engine/Create/Spandrel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Spandrel Spandrel( string name)
+        {
+            return new Spandrel {  Name = name };
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -74,15 +74,21 @@
     <Compile Include="Create\Diaphragm.cs" />
     <Compile Include="Create\EtabsConfig.cs" />
     <Compile Include="Create\MassSource.cs" />
+    <Compile Include="Create\Peir.cs" />
+    <Compile Include="Create\Spandrel.cs" />
     <Compile Include="ModelData.cs" />
     <Compile Include="Modify\SetAutoLengthOffset.cs" />
     <Compile Include="Modify\SetDiaphragm.cs" />
     <Compile Include="Modify\SetInsertionPoint.cs" />
+    <Compile Include="Modify\SetPier.cs" />
+    <Compile Include="Modify\SetSpandrel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\AutoLengthOffset.cs" />
     <Compile Include="Query\Diaphragm.cs" />
     <Compile Include="Query\DiaphragmType.cs" />
     <Compile Include="Query\InsertionPoint.cs" />
+    <Compile Include="Query\Pier.cs" />
+    <Compile Include="Query\Spandrel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ETABS_oM\ETABS_oM.csproj">

--- a/ETABS_Engine/Modify/SetPier.cs
+++ b/ETABS_Engine/Modify/SetPier.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Modify
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static PanelPlanar SetPier(this PanelPlanar panel, Pier pier)
+        {
+            PanelPlanar clone = (PanelPlanar)panel.GetShallowClone();
+
+            clone.CustomData["EtabsPier"] = pier;
+
+            return clone;
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Modify/SetSpandrel.cs
+++ b/ETABS_Engine/Modify/SetSpandrel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Modify
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static PanelPlanar SetSpandrel(this PanelPlanar panel, Spandrel spandrel)
+        {
+            PanelPlanar clone = (PanelPlanar)panel.GetShallowClone();
+
+            clone.CustomData["EtabsSpandrel"] = spandrel;
+
+            return clone;
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Query/Pier.cs
+++ b/ETABS_Engine/Query/Pier.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Query
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Pier Pier(this PanelPlanar panel)
+        {
+            object obj;
+
+            if (panel.CustomData.TryGetValue("EtabsPier", out obj) && obj is Pier)
+            {
+                return (Pier)obj;
+            }
+            return null;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/ETABS_Engine/Query/Spandrel.cs
+++ b/ETABS_Engine/Query/Spandrel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Query
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Spandrel Spandrel(this PanelPlanar panel)
+        {
+            object obj;
+
+            if (panel.CustomData.TryGetValue("EtabsSpandrel", out obj) && obj is Spandrel)
+            {
+                return (Spandrel)obj;
+            }
+            return null;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Config\EtabsConfig.cs" />
     <Compile Include="Elements\Diaphragm.cs" />
     <Compile Include="Elements\Pier.cs" />
+    <Compile Include="Elements\PierForce.cs" />
     <Compile Include="Elements\Spandrel.cs" />
     <Compile Include="Enums\BarInsertionPoint.cs" />
     <Compile Include="Enums\Diaphragm.cs" />

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -45,6 +45,8 @@
   <ItemGroup>
     <Compile Include="Config\EtabsConfig.cs" />
     <Compile Include="Elements\Diaphragm.cs" />
+    <Compile Include="Elements\Pier.cs" />
+    <Compile Include="Elements\Spandrel.cs" />
     <Compile Include="Enums\BarInsertionPoint.cs" />
     <Compile Include="Enums\Diaphragm.cs" />
     <Compile Include="Loads\MassSource.cs" />

--- a/ETABS_oM/Elements/Pier.cs
+++ b/ETABS_oM/Elements/Pier.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Adapters.ETABS.Elements
+{
+    public class Pier : BHoMObject
+    {
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        //Name frombase BHoMObject used for label
+
+        /***************************************************/
+    }
+}

--- a/ETABS_oM/Elements/PierForce.cs
+++ b/ETABS_oM/Elements/PierForce.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Adapters.ETABS.Elements
+{
+    public class PierForce : BH.oM.Structure.Results.BarForce
+    {
+        //Just using this for the name
+        public string Location { get; set; } = "";
+    }
+}

--- a/ETABS_oM/Elements/Spandrel.cs
+++ b/ETABS_oM/Elements/Spandrel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Adapters.ETABS.Elements
+{
+    public class Spandrel : BHoMObject
+    {
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        //Name frombase BHoMObject used for label
+
+        /***************************************************/
+    }
+}

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -46,7 +46,13 @@ namespace BH.Adapter.ETABS
                 List<Diaphragm> diaphragms = panels.Select(x => x.Diaphragm()).Where(x => x != null).ToList();
 
                 this.Replace(diaphragms);
+
+
+                List<Pier> piers = panels.Select(x => x.Pier()).Where(x => x != null).ToList();
+
+                this.Replace(piers);
             }
+
 
             if (typeof(T) == typeof(Level))
             {
@@ -444,6 +450,7 @@ namespace BH.Adapter.ETABS
             return success;
         }
 
+
         /***************************************************/
 
         private bool CreateObject(LinkConstraint bhLinkConstraint)
@@ -548,6 +555,17 @@ namespace BH.Adapter.ETABS
         private void CreatePropertyEvent(string failedProperty, string elemType, string elemName, oM.Reflection.Debuging.EventType eventType)
         {
             Engine.Reflection.Compute.RecordEvent("Failed to set property " + failedProperty + " for the " + elemType + "with id: " + elemName, eventType);
+        }
+
+        /***************************************************/
+
+        private bool CreateObject(Pier bhPier)
+        {
+          //  foreach (PanelPlanar p in bhPier.Panels)
+         //   {
+         //       m_model.AreaObj.SetPier(p.CustomData[AdapterId].ToString(), bhPier.Name);
+        //    }
+            return true;
         }
 
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -12,6 +12,7 @@ using BH.oM.Common.Materials;
 using ETABS2016;
 using BH.Engine.ETABS;
 using BH.oM.Geometry;
+using BH.oM.Architecture.Elements;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
 
@@ -47,6 +48,8 @@ namespace BH.Adapter.ETABS
                 return ReadRigidLink(ids as dynamic);
             else if (type == typeof(LinkConstraint))
                 return ReadLinkConstraints(ids as dynamic);
+            else if (type == typeof(Level))
+                return ReadLevel(ids as dynamic);
 
 
             return new List<IBHoMObject>();//<--- returning null will throw error in replace method of BHOM_Adapter line 34: can't do typeof(null) - returning null does seem the most sensible to return though
@@ -602,6 +605,32 @@ namespace BH.Adapter.ETABS
             }
 
             return linkList;
+        }
+
+        /***************************************************/
+
+        private List<Level> ReadLevel(List<string> ids = null)
+        {
+            List<Level> levellist = new List<Level>();
+            int NumberNames = 0;
+            string[] Names = null;
+
+            if (ids == null)
+            {
+                m_model.Story.GetNameList(ref NumberNames, ref Names);
+                ids = Names.ToList();
+            }
+
+            foreach (string id in ids)
+            {
+                double elevation = 0;
+                int ret = m_model.Story.GetElevation(id, ref elevation);
+           
+                Level lvl = new Level() { Elevation = elevation, Name = id };
+                levellist.Add(lvl);
+            }
+
+            return levellist;
         }
 
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -117,6 +117,12 @@ namespace BH.Adapter.ETABS
                 {
                     Bar bhBar = new Bar();
                     bhBar.CustomData.Add(AdapterId, id);
+                    string PierName = "";
+                    string SpandrelName = "";
+                    m_model.FrameObj.GetPier(id, ref PierName);
+                    m_model.FrameObj.GetSpandrel(id, ref SpandrelName);
+                    bhBar.CustomData.Add("PierName", PierName);
+                    bhBar.CustomData.Add("SpandrelName", SpandrelName);
                     string startId = "";
                     string endId = "";
                     m_model.FrameObj.GetPoints(id, ref startId, ref endId);
@@ -423,6 +429,12 @@ namespace BH.Adapter.ETABS
                 }
 
                 panel.Property = panelProperty;
+                string PierName = "";
+                string SpandrelName = "";
+                m_model.AreaObj.GetPier(id, ref PierName);
+                m_model.AreaObj.GetSpandrel(id, ref SpandrelName);
+                panel.CustomData.Add("PierName", PierName);
+                panel.CustomData.Add("SpandrelName", SpandrelName);
 
                 panelList.Add(panel);
             }

--- a/Etabs_Adapter/CRUD/ReadResults.cs
+++ b/Etabs_Adapter/CRUD/ReadResults.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Common;
 using BH.oM.Structure.Results;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
@@ -90,6 +91,8 @@ namespace BH.Adapter.ETABS
                 results = Helper.GetBarStrain(m_model, ids, cases, divisions);
             else if (type == typeof(BarStress))
                 results = Helper.GetBarStress(m_model, ids, cases, divisions);
+            else if (type == typeof(PierForce))
+                results = Helper.GetPierForce(m_model, ids, cases, divisions);
 
             return results;
         }
@@ -102,6 +105,15 @@ namespace BH.Adapter.ETABS
                 results = Helper.GetMeshForce(m_model, ids, cases, divisions);
             else if (type == typeof(MeshStress))
                 results = Helper.GetMeshStress(m_model, ids, cases, divisions);
+
+            return results;
+        }
+
+        private IEnumerable<IResult> GetPierResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
+        {
+            IEnumerable<PierForce> results = new List<PierForce>();
+
+            results = Helper.GetPierForce(m_model, ids, cases, divisions);
 
             return results;
         }

--- a/Etabs_Adapter/CRUD/UpdateObject.cs
+++ b/Etabs_Adapter/CRUD/UpdateObject.cs
@@ -7,6 +7,7 @@ using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using BH.oM.Common.Materials;
 using BH.Engine.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
@@ -21,6 +22,10 @@ namespace BH.Adapter.ETABS
             if (typeof(T) == typeof(Node))
             {
                 return UpdateObjects(objects as IEnumerable<Node>);
+            }
+            if (typeof(T) == typeof(PanelPlanar))
+            {
+                return UpdateObjects(objects as IEnumerable<PanelPlanar>);
             }
             else
                 return base.UpdateObjects<T>(objects);
@@ -61,6 +66,34 @@ namespace BH.Adapter.ETABS
             return sucess;
         }
 
-        /***************************************************/
-    }
+
+        private bool UpdateObjects(IEnumerable<PanelPlanar> bhPanels)
+        {
+            bool sucess = true;
+
+            foreach (PanelPlanar bhPanel in bhPanels)
+            {
+                Pier pier = bhPanel.Pier();
+                Spandrel spandrel = bhPanel.Spandrel();
+                List<string> pl = new List<string>();
+                string name = bhPanel.CustomData[AdapterId].ToString();
+
+                if (pier != null)
+                {
+                    int ret = m_model.PierLabel.SetPier(pier.Name);
+                     ret = m_model.AreaObj.SetPier(name, pier.Name);
+                }
+                if (spandrel != null)
+                {
+                    int ret = m_model.SpandrelLabel.SetSpandrel(spandrel.Name,false);
+                    ret = m_model.AreaObj.SetSpandrel(name, spandrel.Name);
+                }
+            }
+            return sucess;
+        }
+
+
+
+    /***************************************************/
+}
 }

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.ETABS
                     m_model = m_app.SapModel;
                     if (System.IO.File.Exists(filePath))
                         m_model.File.OpenFile(filePath);
-                    m_model.SetPresentUnits(eUnits.kip_ft_F);
+                    m_model.SetPresentUnits(eUnits.N_m_C);
                 }
                 else
                 {

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.ETABS
                     m_model = m_app.SapModel;
                     if (System.IO.File.Exists(filePath))
                         m_model.File.OpenFile(filePath);
-                    m_model.SetPresentUnits(eUnits.N_m_C);
+                    m_model.SetPresentUnits(eUnits.kip_ft_F);
                 }
                 else
                 {

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
+using BH.oM.Structure.Elements;
 using BH.oM.Common;
 using ETABS2016;
 using BH.oM.Adapters.ETABS.Elements;
@@ -205,12 +206,17 @@ namespace BH.Adapter.ETABS
             List<string> barIds = new List<string>();
             List<BarForce> barForces = new List<BarForce>();
 
-            if (ids == null)
+            if (ids == null || ids.Count ==0)
             {
                 int bars = 0;
                 string[] names = null;
                 model.FrameObj.GetNameList(ref bars, ref names);
                 barIds = names.ToList();
+            }
+            else
+            {
+                foreach (var id in ids)
+                { barIds.Add(id.ToString()); }
             }
 
             if (cases == null)
@@ -222,6 +228,25 @@ namespace BH.Adapter.ETABS
                 model.RespCombo.GetNameList(ref casesCount, ref names);
                 loadcaseIds.AddRange(names);
             }
+            else
+            {
+                for (int i = 0; i < cases.Count; i++)
+                {
+                    if (cases[i].GetType().Name.ToString() == "LoadCase")
+                    {
+                        BH.oM.Structure.Loads.Loadcase tempcase = (BH.oM.Structure.Loads.Loadcase)cases[i];
+                        loadcaseIds.Add(tempcase.Name);
+                    }
+                    else if (cases[i].GetType().Name.ToString() == "LoadCombination")
+                    { 
+                            BH.oM.Structure.Loads.LoadCombination tempcombo = (BH.oM.Structure.Loads.LoadCombination)cases[i];
+                            loadcaseIds.Add(tempcombo.Name);
+                    }
+                }
+            }
+
+                
+            
 
 
             int resultCount = 0;

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -242,8 +242,7 @@ namespace BH.Adapter.ETABS
                     barIds.Add(ids[i].ToString());
                 }
             }
-            else
-            {
+
                 for (int i = 0; i < cases.Count; i++)
                 {
                     if (cases[i].GetType().Name.ToString() == "LoadCase")
@@ -257,7 +256,7 @@ namespace BH.Adapter.ETABS
                             loadcaseIds.Add(tempcombo.Name);
                     }
                 }
-            }
+       
 
                 
             

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Common;
 using ETABS2016;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
@@ -292,6 +293,104 @@ namespace BH.Adapter.ETABS
 
             return barForces;
 
+        }
+
+        public static List<PierForce> GetPierForce(cSapModel model, IList ids = null, IList cases = null, int divisions = 5)
+        {
+
+            List<string> loadcaseIds = new List<string>();
+            List<string> barIds = new List<string>();
+            List<PierForce> pierForces = new List<PierForce>();
+
+            if (ids == null)
+            {
+                int bars = 0;
+                string[] names = null;
+                model.FrameObj.GetNameList(ref bars, ref names);
+                barIds = names.ToList();
+            }
+
+            if (cases == null)
+            {
+                int casesCount = 0;
+                string[] names = null;
+                model.LoadCases.GetNameList(ref casesCount, ref names);
+                loadcaseIds = names.ToList();
+                model.RespCombo.GetNameList(ref casesCount, ref names);
+                loadcaseIds.AddRange(names);
+            }
+
+
+            int resultCount = 0;
+            string[] loadcaseNames = null;
+            string[] objects = null;
+            string[] elm = null;
+            double[] objStation = null;
+            double[] elmStation = null;
+            double[] stepNum = null;
+            string[] stepType = null;
+
+            int NumberResults = 0;
+            string[] StoryName = null;
+            string[] PierName = null;
+            string[] Location = null;
+
+            double[] P = null;
+            double[] V2 = null;
+            double[] V3 = null;
+            double[] T = null;
+            double[] M2 = null;
+            double[] M3 = null;
+
+            int type = 0;
+            double segSize = 0;
+            bool op1 = false;
+            bool op2 = false;
+
+
+            model.Results.Setup.DeselectAllCasesAndCombosForOutput();
+
+            for (int loadcase = 0; loadcase < loadcaseIds.Count; loadcase++)
+            {
+                if (model.Results.Setup.SetCaseSelectedForOutput(loadcaseIds[loadcase]) != 0)
+                {
+                    model.Results.Setup.SetComboSelectedForOutput(loadcaseIds[loadcase]);
+                }
+            }
+
+            //List<BarForce<string, string, string>> barForces = new List<BarForce<string, string, string>>();
+            int counter = 1;
+
+                int ret = model.Results.PierForce(ref NumberResults, ref  StoryName,ref PierName, ref loadcaseNames,ref Location, ref P, ref V2, ref V3, ref T, ref M2, ref M3);
+                if (ret == 0)
+                {
+                    for (int j = 0; j < NumberResults; j++)
+                    {
+                    int position = 0;
+                    if (Location[j].ToUpper().Contains("BOTTOM"))
+                    {
+                        position = 1;
+                    }
+                        PierForce bf = new PierForce()
+                        {
+                            ResultCase = loadcaseNames[j],
+                            ObjectId = PierName[j],
+                            MX = T[j],
+                            MY = M2[j],
+                            MZ = M3[j],
+                            FX = P[j],
+                            FY = V2[j],
+                            FZ = V3[j],
+                            //Divisions = divisions,
+                            Position = position,
+                           // TimeStep = stepNum[j]
+                        };
+                       bf.Location = StoryName[j];
+                        pierForces.Add(bf);
+                    }
+                    
+                }
+            return pierForces;
         }
 
         public static List<BarResult> GetBarStrain(cSapModel model, IList ids = null, IList cases = null, int divisions = 5)


### PR DESCRIPTION
 ### Issues addressed by this PR
Issue #128 

Closes # 128

Added OM objects for piers and spandrels.  Currently only updating panels in etabs already with pier and spandrel labels.  

@IsakNaslundBh we've talked about this before...If there are issues let me know, I just had time this week for once to get these things up there and I feel like this stuff's pretty important for the vast majority of ETABs users and can save a lot of time.

 ### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Etabs_Toolkit-Issue128-PiersandSpandrels/ETABsToolkit_Issue%23128.gh?csf=1&e=DMIxca
