### PR TITLE
Etabs toolkit issue131 fix wall reading

### DIFF
--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -288,6 +288,7 @@ namespace BH.Adapter.ETABS
                 ISurfaceProperty bhProperty = null;
                 eSlabType slabType = eSlabType.Slab;
                 eShellType shellType = eShellType.ShellThin;
+                eWallPropType wallType = eWallPropType.Specified;
                 string material = "";
                 double thickness = 0;
                 int colour = 0;
@@ -302,15 +303,22 @@ namespace BH.Adapter.ETABS
                 double[] modifiers = new double[] { };
                 bool hasModifiers = false;
 
+                m_model.PropArea.GetWall(id, ref wallType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
                 m_model.PropArea.GetSlab(id, ref slabType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
+
                 if (m_model.PropArea.GetModifiers(id, ref modifiers) == 0)
                     hasModifiers = true;
 
-                if (thickness==0)
+                if (wallType == eWallPropType.AutoSelectList)
                 {
-                    eWallPropType wallProperty = eWallPropType.AutoSelectList;
-                    m_model.PropArea.GetWall(id, ref wallProperty, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
+                    string[] propList = null;
+                    string currentProperty = "";
+
+                    m_model.PropArea.GetWallAutoSelectList(id, ref propList, ref currentProperty);
+                    m_model.PropArea.GetWall(currentProperty, ref wallType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
+
                     ConstantThickness panelConstant = new ConstantThickness();
+                    panelConstant.Name = id;
                     panelConstant.CustomData[AdapterId] = id;
                     panelConstant.Material = ReadMaterials(new List<string>() { material })[0];
                     panelConstant.Thickness = thickness;

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -458,17 +458,14 @@ namespace BH.Adapter.ETABS
                 
                 Polyline pl = Helper.GetPanelPerimeter(m_model, id);
 
-                Edge edge = new Edge();
-                edge.Curve = pl;
-                //edge.Constraint = new Constraint4DOF();// <---- cannot see anyway to set this via API and for some reason constraints are not being set in old version of etabs toolkit TODO
+                panel.ExternalEdges = pl.SubParts().Select(x => new Edge { Curve = x }).ToList();
 
-                panel.ExternalEdges = new List<Edge>() { edge };
                 foreach(KeyValuePair<string, Polyline> kvp in openingDict)
                 {
                     if (pl.IsContaining(kvp.Value.ControlPoints))
                     {
                         Opening opening = new Opening();
-                        opening.Edges = new List<Edge>() { new Edge() { Curve = kvp.Value } };
+                        opening.Edges = kvp.Value.SubParts().Select(x => new Edge { Curve = x }).ToList();
                         panel.Openings.Add(opening);
                     }
                 }

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -303,8 +303,9 @@ namespace BH.Adapter.ETABS
                 double[] modifiers = new double[] { };
                 bool hasModifiers = false;
 
-                m_model.PropArea.GetWall(id, ref wallType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
-                m_model.PropArea.GetSlab(id, ref slabType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
+                int ret = m_model.PropArea.GetSlab(id, ref slabType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
+                if (ret != 0)
+                    m_model.PropArea.GetWall(id, ref wallType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
 
                 if (m_model.PropArea.GetModifiers(id, ref modifiers) == 0)
                     hasModifiers = true;
@@ -318,7 +319,7 @@ namespace BH.Adapter.ETABS
                     m_model.PropArea.GetWall(currentProperty, ref wallType, ref shellType, ref material, ref thickness, ref colour, ref notes, ref guid);
 
                     ConstantThickness panelConstant = new ConstantThickness();
-                    panelConstant.Name = id;
+                    panelConstant.Name = currentProperty;
                     panelConstant.CustomData[AdapterId] = id;
                     panelConstant.Material = ReadMaterials(new List<string>() { material })[0];
                     panelConstant.Thickness = thickness;


### PR DESCRIPTION
 ### Issues addressed by this PR
 Closes #131

 If GetSlab returns nonzero (if the shell is a wall), the toolkit calls GetWall.
Also, since we're calling GetWall, we have available the eWallPropType, so I changed the autoselect list handling bit to just test if the eWallPropType is AutoSelectList, then used GetWallAutoSelect to get the starter property for the autoselect list and read that wall property.

 ### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/ETABS_Toolkit-Issue131-ReadWallNames?csf=1&e=OHeGXj

 ### Changelog
#### Added
Read SurfaceProperty now reads names of wall sections.

