### PR TITLE
Etabs toolkit issue#128v2

### DIFF
--- a/ETABS_Engine/Create/Pier.cs
+++ b/ETABS_Engine/Create/Pier.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Pier Pier(string name)
+        {
+            return new Pier { Name = name };
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Create/Spandrel.cs
+++ b/ETABS_Engine/Create/Spandrel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Spandrel Spandrel(string name)
+        {
+            return new Spandrel { Name = name };
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -86,17 +86,23 @@
     <Compile Include="Create\Diaphragm.cs" />
     <Compile Include="Create\EtabsConfig.cs" />
     <Compile Include="Create\MassSource.cs" />
+    <Compile Include="Create\Pier.cs" />
+    <Compile Include="Create\Spandrel.cs" />
     <Compile Include="ModelData.cs" />
     <Compile Include="Modify\SetAutoLengthOffset.cs" />
     <Compile Include="Modify\SetDiaphragm.cs" />
     <Compile Include="Modify\SetInsertionPoint.cs" />
+    <Compile Include="Modify\SetPier.cs" />
     <Compile Include="Modify\SetShellType.cs" />
+    <Compile Include="Modify\SetSpandrel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\AutoLengthOffset.cs" />
     <Compile Include="Query\Diaphragm.cs" />
     <Compile Include="Query\DiaphragmType.cs" />
     <Compile Include="Query\EtabsShellType.cs" />
     <Compile Include="Query\InsertionPoint.cs" />
+    <Compile Include="Query\Pier.cs" />
+    <Compile Include="Query\Spandrel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ETABS_oM\ETABS_oM.csproj">

--- a/ETABS_Engine/Modify/SetPier.cs
+++ b/ETABS_Engine/Modify/SetPier.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Modify
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static PanelPlanar SetPier(this PanelPlanar panel, Pier pier)
+        {
+            PanelPlanar clone = (PanelPlanar)panel.GetShallowClone();
+
+            clone.CustomData["EtabsPier"] = pier;
+
+            return clone;
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Modify/SetSpandrel.cs
+++ b/ETABS_Engine/Modify/SetSpandrel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Modify
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static PanelPlanar SetSpandrel(this PanelPlanar panel, Spandrel spandrel)
+        {
+            PanelPlanar clone = (PanelPlanar)panel.GetShallowClone();
+
+            clone.CustomData["EtabsSpandrel"] = spandrel;
+
+            return clone;
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Engine/Query/Pier.cs
+++ b/ETABS_Engine/Query/Pier.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Query
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Pier Pier(this PanelPlanar panel)
+        {
+            object obj;
+
+            if (panel.CustomData.TryGetValue("EtabsPier", out obj) && obj is Pier)
+            {
+                return (Pier)obj;
+            }
+            return null;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/ETABS_Engine/Query/Spandrel.cs
+++ b/ETABS_Engine/Query/Spandrel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Adapters.ETABS.Elements;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Query
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Spandrel Spandrel(this PanelPlanar panel)
+        {
+            object obj;
+
+            if (panel.CustomData.TryGetValue("EtabsSpandrel", out obj) && obj is Spandrel)
+            {
+                return (Spandrel)obj;
+            }
+            return null;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -58,6 +58,9 @@
   <ItemGroup>
     <Compile Include="Config\EtabsConfig.cs" />
     <Compile Include="Elements\Diaphragm.cs" />
+    <Compile Include="Elements\Pier.cs" />
+    <Compile Include="Elements\PierForce.cs" />
+    <Compile Include="Elements\Spandrel.cs" />
     <Compile Include="Enums\BarInsertionPoint.cs" />
     <Compile Include="Enums\Diaphragm.cs" />
     <Compile Include="Enums\ShellType.cs" />

--- a/ETABS_oM/Elements/Pier.cs
+++ b/ETABS_oM/Elements/Pier.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Adapters.ETABS.Elements
+{
+    public class Pier : BHoMObject
+    {
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        //Name frombase BHoMObject used for label
+
+        /***************************************************/
+    }
+}

--- a/ETABS_oM/Elements/PierForce.cs
+++ b/ETABS_oM/Elements/PierForce.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Adapters.ETABS.Elements
+{
+    public class PierForce : BH.oM.Structure.Results.BarForce
+    {
+        //Just using this for the name
+        public string Location { get; set; } = "";
+    }
+}

--- a/ETABS_oM/Elements/Spandrel.cs
+++ b/ETABS_oM/Elements/Spandrel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Adapters.ETABS.Elements
+{
+    public class Spandrel : BHoMObject
+    {
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        //Name frombase BHoMObject used for label
+
+        /***************************************************/
+    }
+}

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -71,10 +71,6 @@ namespace BH.Adapter.ETABS
                 List<Diaphragm> diaphragms = panels.Select(x => x.Diaphragm()).Where(x => x != null).ToList();
 
                 this.Replace(diaphragms);
-
-                List<Pier> piers = panels.Select(x => x.Pier()).Where(x => x != null).ToList();
-
-                this.Replace(piers);
             }
 
             if (typeof(T) == typeof(Level))

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -71,6 +71,10 @@ namespace BH.Adapter.ETABS
                 List<Diaphragm> diaphragms = panels.Select(x => x.Diaphragm()).Where(x => x != null).ToList();
 
                 this.Replace(diaphragms);
+
+                List<Pier> piers = panels.Select(x => x.Pier()).Where(x => x != null).ToList();
+
+                this.Replace(piers);
             }
 
             if (typeof(T) == typeof(Level))

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -39,6 +39,7 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
 using BH.oM.Architecture.Elements;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
@@ -139,12 +140,6 @@ namespace BH.Adapter.ETABS
                 {
                     Bar bhBar = new Bar();
                     bhBar.CustomData.Add(AdapterId, id);
-                    string PierName = "";
-                    string SpandrelName = "";
-                    m_model.FrameObj.GetPier(id, ref PierName);
-                    m_model.FrameObj.GetSpandrel(id, ref SpandrelName);
-                    bhBar.CustomData.Add("PierName", PierName);
-                    bhBar.CustomData.Add("SpandrelName", SpandrelName);
                     string startId = "";
                     string endId = "";
                     m_model.FrameObj.GetPoints(id, ref startId, ref endId);
@@ -483,8 +478,8 @@ namespace BH.Adapter.ETABS
                 string SpandrelName = "";
                 m_model.AreaObj.GetPier(id, ref PierName);
                 m_model.AreaObj.GetSpandrel(id, ref SpandrelName);
-                panel.CustomData.Add("PierName", PierName);
-                panel.CustomData.Add("SpandrelName", SpandrelName);
+                panel.CustomData.Add("Pier",  new Pier { Name = PierName });
+                panel.CustomData.Add("Spandrel", new Spandrel { Name = SpandrelName });
 
                 panelList.Add(panel);
             }
@@ -696,5 +691,6 @@ namespace BH.Adapter.ETABS
         }
 
         /***************************************************/
+
     }
 }

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -478,8 +478,8 @@ namespace BH.Adapter.ETABS
                 string SpandrelName = "";
                 m_model.AreaObj.GetPier(id, ref PierName);
                 m_model.AreaObj.GetSpandrel(id, ref SpandrelName);
-                panel.SetSpandrel(new Spandrel { Name = SpandrelName });
-                panel.SetPier(new Pier { Name = PierName });
+                panel = panel.SetSpandrel(new Spandrel { Name = SpandrelName });
+                panel = panel.SetPier(new Pier { Name = PierName });
 
                 panelList.Add(panel);
             }

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -478,8 +478,8 @@ namespace BH.Adapter.ETABS
                 string SpandrelName = "";
                 m_model.AreaObj.GetPier(id, ref PierName);
                 m_model.AreaObj.GetSpandrel(id, ref SpandrelName);
-                panel.CustomData.Add("Pier",  new Pier { Name = PierName });
-                panel.CustomData.Add("Spandrel", new Spandrel { Name = SpandrelName });
+                panel.SetSpandrel(new Spandrel { Name = SpandrelName });
+                panel.SetPier(new Pier { Name = PierName });
 
                 panelList.Add(panel);
             }

--- a/Etabs_Adapter/CRUD/ReadResults.cs
+++ b/Etabs_Adapter/CRUD/ReadResults.cs
@@ -131,16 +131,6 @@ namespace BH.Adapter.ETABS
             return results;
         }
 
-        private IEnumerable<IResult> GetPierResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
-        {
-            IEnumerable<PierForce> results = new List<PierForce>();
-
-            results = Helper.GetPierForce(m_model, ids, cases, divisions);
-
-            return results;
-        }
-
-
     }
 
 }

--- a/Etabs_Adapter/CRUD/ReadResults.cs
+++ b/Etabs_Adapter/CRUD/ReadResults.cs
@@ -28,6 +28,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Common;
 using BH.oM.Structure.Results;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
@@ -112,6 +113,8 @@ namespace BH.Adapter.ETABS
                 results = Helper.GetBarStrain(m_model, ids, cases, divisions);
             else if (type == typeof(BarStress))
                 results = Helper.GetBarStress(m_model, ids, cases, divisions);
+            else if (type == typeof(PierForce))
+                results = Helper.GetPierForce(m_model, ids, cases, divisions);
 
             return results;
         }
@@ -128,5 +131,16 @@ namespace BH.Adapter.ETABS
             return results;
         }
 
+        private IEnumerable<IResult> GetPierResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
+        {
+            IEnumerable<PierForce> results = new List<PierForce>();
+
+            results = Helper.GetPierForce(m_model, ids, cases, divisions);
+
+            return results;
+        }
+
+
     }
+
 }

--- a/Etabs_Adapter/CRUD/UpdateObject.cs
+++ b/Etabs_Adapter/CRUD/UpdateObject.cs
@@ -31,6 +31,7 @@ using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using BH.oM.Common.Materials;
 using BH.Engine.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
@@ -45,6 +46,10 @@ namespace BH.Adapter.ETABS
             if (typeof(T) == typeof(Node))
             {
                 return UpdateObjects(objects as IEnumerable<Node>);
+            }
+            if (typeof(T) == typeof(PanelPlanar))
+            {
+                return UpdateObjects(objects as IEnumerable<PanelPlanar>);
             }
             else
                 return base.UpdateObjects<T>(objects);
@@ -84,6 +89,32 @@ namespace BH.Adapter.ETABS
 
             return sucess;
         }
+
+        private bool UpdateObjects(IEnumerable<PanelPlanar> bhPanels)
+        {
+            bool sucess = true;
+
+            foreach (PanelPlanar bhPanel in bhPanels)
+            {
+                Pier pier = bhPanel.Pier();
+                Spandrel spandrel = bhPanel.Spandrel();
+                List<string> pl = new List<string>();
+                string name = bhPanel.CustomData[AdapterId].ToString();
+
+                if (pier != null)
+                {
+                    int ret = m_model.PierLabel.SetPier(pier.Name);
+                    ret = m_model.AreaObj.SetPier(name, pier.Name);
+                }
+                if (spandrel != null)
+                {
+                    int ret = m_model.SpandrelLabel.SetSpandrel(spandrel.Name, false);
+                    ret = m_model.AreaObj.SetSpandrel(name, spandrel.Name);
+                }
+            }
+            return sucess;
+        }
+
 
         /***************************************************/
     }

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -320,14 +320,7 @@ namespace BH.Adapter.ETABS
 
             loadcaseIds = CheckAndGetCases(model, cases);
 
-            int resultCount = 0;
             string[] loadcaseNames = null;
-            string[] objects = null;
-            string[] elm = null;
-            double[] objStation = null;
-            double[] elmStation = null;
-            double[] stepNum = null;
-            string[] stepType = null;
 
             int numberResults = 0;
             string[] storyName = null;
@@ -341,10 +334,6 @@ namespace BH.Adapter.ETABS
             double[] m2 = null;
             double[] m3 = null;
 
-            int type = 0;
-            double segSize = 0;
-            bool op1 = false;
-            bool op2 = false;
 
 
             model.Results.Setup.DeselectAllCasesAndCombosForOutput();
@@ -356,8 +345,6 @@ namespace BH.Adapter.ETABS
                     model.Results.Setup.SetComboSelectedForOutput(loadcaseIds[loadcase]);
                 }
             }
-
-            int counter = 1;
 
             int ret = model.Results.PierForce(ref numberResults, ref storyName, ref pierName, ref loadcaseNames, ref location, ref p, ref v2, ref v3, ref t, ref m2, ref m3);
             if (ret == 0)

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -334,8 +334,6 @@ namespace BH.Adapter.ETABS
             double[] m2 = null;
             double[] m3 = null;
 
-
-
             model.Results.Setup.DeselectAllCasesAndCombosForOutput();
 
             for (int loadcase = 0; loadcase < loadcaseIds.Count; loadcase++)

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -329,20 +329,13 @@ namespace BH.Adapter.ETABS
             return barForces;
         }
 
+
         public static List<PierForce> GetPierForce(cSapModel model, IList ids = null, IList cases = null, int divisions = 5)
         {
 
             List<string> loadcaseIds = new List<string>();
             List<string> barIds = new List<string>();
             List<PierForce> pierForces = new List<PierForce>();
-
-            if (ids == null)
-            {
-                int bars = 0;
-                string[] names = null;
-                model.FrameObj.GetNameList(ref bars, ref names);
-                barIds = names.ToList();
-            }
 
             if (cases == null)
             {
@@ -392,7 +385,6 @@ namespace BH.Adapter.ETABS
                 }
             }
 
-            //List<BarForce<string, string, string>> barForces = new List<BarForce<string, string, string>>();
             int counter = 1;
 
             int ret = model.Results.PierForce(ref NumberResults, ref StoryName, ref PierName, ref loadcaseNames, ref Location, ref P, ref V2, ref V3, ref T, ref M2, ref M3);

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -246,24 +246,6 @@ namespace BH.Adapter.ETABS
             //Get out loadcases, get all for null list
             loadcaseIds = CheckAndGetCases(model, cases);
 
-            for (int i = 0; i < cases.Count; i++)
-            {
-                if (cases[i].GetType().Name.ToString() == "LoadCase")
-                {
-                    BH.oM.Structure.Loads.Loadcase tempcase = (BH.oM.Structure.Loads.Loadcase)cases[i];
-                    loadcaseIds.Add(tempcase.Name);
-                }
-                else if (cases[i].GetType().Name.ToString() == "LoadCombination")
-                {
-                    BH.oM.Structure.Loads.LoadCombination tempcombo = (BH.oM.Structure.Loads.LoadCombination)cases[i];
-                    loadcaseIds.Add(tempcombo.Name);
-                }
-            }
-
-
-
-
-
             int resultCount = 0;
             string[] loadcaseNames = null;
             string[] objects = null;
@@ -332,15 +314,11 @@ namespace BH.Adapter.ETABS
 
         public static List<PierForce> GetPierForce(cSapModel model, IList ids = null, IList cases = null, int divisions = 5)
         {
-
             List<string> loadcaseIds = new List<string>();
             List<string> barIds = new List<string>();
             List<PierForce> pierForces = new List<PierForce>();
 
-            if (cases == null)
-            {
-                loadcaseIds = CheckAndGetCases(model, cases);
-            }
+            loadcaseIds = CheckAndGetCases(model, cases);
 
             int resultCount = 0;
             string[] loadcaseNames = null;
@@ -515,7 +493,7 @@ namespace BH.Adapter.ETABS
         {
             List<string> loadcaseIds = new List<string>();
                 
-            if (cases == null)
+            if (cases == null||cases.Count == 0)
             {
                 int Count = 0;
                 string[] case_names = null;
@@ -531,7 +509,13 @@ namespace BH.Adapter.ETABS
             {
                 for (int i = 0; i < cases.Count; i++)
                 {
-                    loadcaseIds.Add(cases[i].ToString());
+                    if (cases[i] is BH.oM.Structure.Loads.ICase)
+                    {
+                        string id = CaseNameToCSI(cases[i] as BH.oM.Structure.Loads.ICase);
+                        loadcaseIds.Add(id);
+                    }
+                    else
+                        loadcaseIds.Add(cases[i].ToString());
                 }
             }
 

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -339,14 +339,8 @@ namespace BH.Adapter.ETABS
 
             if (cases == null)
             {
-                int casesCount = 0;
-                string[] names = null;
-                model.LoadCases.GetNameList(ref casesCount, ref names);
-                loadcaseIds = names.ToList();
-                model.RespCombo.GetNameList(ref casesCount, ref names);
-                loadcaseIds.AddRange(names);
+                loadcaseIds = CheckAndGetCases(model, cases);
             }
-
 
             int resultCount = 0;
             string[] loadcaseNames = null;
@@ -543,6 +537,8 @@ namespace BH.Adapter.ETABS
 
             return loadcaseIds;
         }
+
+
 
         #endregion
 

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -329,17 +329,17 @@ namespace BH.Adapter.ETABS
             double[] stepNum = null;
             string[] stepType = null;
 
-            int NumberResults = 0;
-            string[] StoryName = null;
-            string[] PierName = null;
-            string[] Location = null;
+            int numberResults = 0;
+            string[] storyName = null;
+            string[] pierName = null;
+            string[] location = null;
 
-            double[] P = null;
-            double[] V2 = null;
-            double[] V3 = null;
-            double[] T = null;
-            double[] M2 = null;
-            double[] M3 = null;
+            double[] p = null;
+            double[] v2 = null;
+            double[] v3 = null;
+            double[] t = null;
+            double[] m2 = null;
+            double[] m3 = null;
 
             int type = 0;
             double segSize = 0;
@@ -359,31 +359,31 @@ namespace BH.Adapter.ETABS
 
             int counter = 1;
 
-            int ret = model.Results.PierForce(ref NumberResults, ref StoryName, ref PierName, ref loadcaseNames, ref Location, ref P, ref V2, ref V3, ref T, ref M2, ref M3);
+            int ret = model.Results.PierForce(ref numberResults, ref storyName, ref pierName, ref loadcaseNames, ref location, ref p, ref v2, ref v3, ref t, ref m2, ref m3);
             if (ret == 0)
             {
-                for (int j = 0; j < NumberResults; j++)
+                for (int j = 0; j < numberResults; j++)
                 {
                     int position = 0;
-                    if (Location[j].ToUpper().Contains("BOTTOM"))
+                    if (location[j].ToUpper().Contains("BOTTOM"))
                     {
                         position = 1;
                     }
                     PierForce bf = new PierForce()
                     {
                         ResultCase = loadcaseNames[j],
-                        ObjectId = PierName[j],
-                        MX = T[j],
-                        MY = M2[j],
-                        MZ = M3[j],
-                        FX = P[j],
-                        FY = V2[j],
-                        FZ = V3[j],
+                        ObjectId = pierName[j],
+                        MX = t[j],
+                        MY = m2[j],
+                        MZ = m3[j],
+                        FX = p[j],
+                        FY = v2[j],
+                        FZ = v3[j],
                         //Divisions = divisions,
                         Position = position,
                         // TimeStep = stepNum[j]
                     };
-                    bf.Location = StoryName[j];
+                    bf.Location = storyName[j];
                     pierForces.Add(bf);
                 }
 


### PR DESCRIPTION
Issues addressed by this PR
Issue #128
Closes # 128
Added OM objects for piers and spandrels. Currently only updating panels in etabs already with pier and spandrel labels.
@IsakNaslundBh we've talked about this before...If there are issues let me know, I just had time this week for once to get these things up there and I feel like this stuff's pretty important for the vast majority of ETABs users and can save a lot of time.
Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Etabs_Toolkit-Issue128-PiersandSpandrels/ETABsToolkit_Issue%23128.gh?csf=1&e=DMIxca
