### PR TITLE
Etabs toolkit issue140 control auto offset rigid zone factor

### DIFF
--- a/ETABS_Engine/Create/Pier.cs
+++ b/ETABS_Engine/Create/Pier.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_Engine/Create/Spandrel.cs
+++ b/ETABS_Engine/Create/Spandrel.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_Engine/Modify/SetAutoLengthOffset.cs
+++ b/ETABS_Engine/Modify/SetAutoLengthOffset.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/ETABS_Engine/Modify/SetAutoLengthOffset.cs
+++ b/ETABS_Engine/Modify/SetAutoLengthOffset.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
-using BH.oM.Adapters.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Engine.ETABS
 {
@@ -39,9 +39,22 @@ namespace BH.Engine.ETABS
 
         public static Bar SetAutoLengthOffset(this Bar bar, bool autoLengthOffset)
         {
+            return SetAutoLengthOffset(bar, autoLengthOffset, 1.0);
+        }
+
+        /***************************************************/
+
+        public static Bar SetAutoLengthOffset(this Bar bar, bool autoLengthOffset, double rigidZoneFactor)
+        {
+            if (rigidZoneFactor < 0 || rigidZoneFactor > 1.0)
+            {
+                rigidZoneFactor = Math.Min(Math.Max(0, rigidZoneFactor), 1);
+                Engine.Reflection.Compute.RecordWarning("Rigid zone factor needs to be between 0 and 1. The value has been updated to fit in this interval");
+            }
+
             Bar clone = (Bar)bar.GetShallowClone();
 
-            clone.CustomData["EtabsAutoLengthOffset"] = autoLengthOffset;
+            clone.CustomData["EtabsAutoLengthOffset"] = new AutoLengthOffset { AutoOffset = autoLengthOffset, RigidZoneFactor = rigidZoneFactor };
 
             return clone;
         }

--- a/ETABS_Engine/Modify/SetPier.cs
+++ b/ETABS_Engine/Modify/SetPier.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_Engine/Modify/SetSpandrel.cs
+++ b/ETABS_Engine/Modify/SetSpandrel.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_Engine/Query/AutoLengthOffset.cs
+++ b/ETABS_Engine/Query/AutoLengthOffset.cs
@@ -37,28 +37,15 @@ namespace BH.Engine.ETABS
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static bool AutoLengthOffset(this Bar bar)
+        public static AutoLengthOffset AutoLengthOffset(this Bar bar)
         {
             object obj;
 
             if (bar.CustomData.TryGetValue("EtabsAutoLengthOffset", out obj) && obj is AutoLengthOffset)
             {
-                return ((AutoLengthOffset)obj).AutoOffset;
+                return (AutoLengthOffset)obj;
             }
-            return false;
-        }
-
-        /***************************************************/
-
-        public static double AutoLengthOffsetRigidZoneFactor(this Bar bar)
-        {
-            object obj;
-
-            if (bar.CustomData.TryGetValue("EtabsAutoLengthOffset", out obj) && obj is AutoLengthOffset)
-            {
-                return ((AutoLengthOffset)obj).RigidZoneFactor;
-            }
-            return 0;
+            return null;
         }
 
         /***************************************************/

--- a/ETABS_Engine/Query/Pier.cs
+++ b/ETABS_Engine/Query/Pier.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_Engine/Query/Spandrel.cs
+++ b/ETABS_Engine/Query/Spandrel.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config\EtabsConfig.cs" />
+    <Compile Include="Elements\AutoLengthOffset.cs" />
     <Compile Include="Elements\Diaphragm.cs" />
     <Compile Include="Elements\Pier.cs" />
     <Compile Include="Elements\PierForce.cs" />

--- a/ETABS_oM/Elements/AutoLengthOffset.cs
+++ b/ETABS_oM/Elements/AutoLengthOffset.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/ETABS_oM/Elements/AutoLengthOffset.cs
+++ b/ETABS_oM/Elements/AutoLengthOffset.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
  *
@@ -20,48 +20,23 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BH.oM.Structure.Elements;
-using BH.oM.Adapters.ETABS.Elements;
 
-namespace BH.Engine.ETABS
+using BH.oM.Base;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.ETABS.Elements
 {
-    public static partial class Query
+    public class AutoLengthOffset : BHoMObject
     {
-
         /***************************************************/
-        /**** Public Methods                            ****/
-        /***************************************************/
-
-        public static bool AutoLengthOffset(this Bar bar)
-        {
-            object obj;
-
-            if (bar.CustomData.TryGetValue("EtabsAutoLengthOffset", out obj) && obj is AutoLengthOffset)
-            {
-                return ((AutoLengthOffset)obj).AutoOffset;
-            }
-            return false;
-        }
-
+        /**** Public Properties                         ****/
         /***************************************************/
 
-        public static double AutoLengthOffsetRigidZoneFactor(this Bar bar)
-        {
-            object obj;
+        public bool AutoOffset { get; set; } = false;
 
-            if (bar.CustomData.TryGetValue("EtabsAutoLengthOffset", out obj) && obj is AutoLengthOffset)
-            {
-                return ((AutoLengthOffset)obj).RigidZoneFactor;
-            }
-            return 0;
-        }
+        [Description("Value descibing the factor of the rigid zone. Needs to be between 0 and 1")]
+        public double RigidZoneFactor { get; set; } = 1.0;
 
         /***************************************************/
-
     }
 }

--- a/ETABS_oM/Elements/Pier.cs
+++ b/ETABS_oM/Elements/Pier.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_oM/Elements/PierForce.cs
+++ b/ETABS_oM/Elements/PierForce.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETABS_oM/Elements/Spandrel.cs
+++ b/ETABS_oM/Elements/Spandrel.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -204,7 +204,10 @@ namespace BH.Adapter.ETABS
 
             if (bhBar.AutoLengthOffset())
             {
-                if (m_model.FrameObj.SetEndLengthOffset(name, true, 0, 0, 0) != 0)
+                //the Rigid Zone Factor is not picked up when setting the auto length = true for the method call. Hence need to call this method twice.
+                int retAutoLEngthOffset = m_model.FrameObj.SetEndLengthOffset(name, false, 0, 0, bhBar.AutoLengthOffsetRigidZoneFactor());
+                retAutoLEngthOffset += m_model.FrameObj.SetEndLengthOffset(name, true, 0, 0, 0);
+                if (retAutoLEngthOffset != 0)
                 {
                     CreatePropertyWarning("Auto length offset", "Bar", name);
                     ret++;

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -202,11 +202,12 @@ namespace BH.Adapter.ETABS
                 }
             }
 
-            if (bhBar.AutoLengthOffset())
+            AutoLengthOffset autoLengthOffset = bhBar.AutoLengthOffset();
+            if (autoLengthOffset != null)
             {
                 //the Rigid Zone Factor is not picked up when setting the auto length = true for the method call. Hence need to call this method twice.
-                int retAutoLEngthOffset = m_model.FrameObj.SetEndLengthOffset(name, false, 0, 0, bhBar.AutoLengthOffsetRigidZoneFactor());
-                retAutoLEngthOffset += m_model.FrameObj.SetEndLengthOffset(name, true, 0, 0, 0);
+                int retAutoLEngthOffset = m_model.FrameObj.SetEndLengthOffset(name, false, 0, 0, autoLengthOffset.RigidZoneFactor);
+                retAutoLEngthOffset += m_model.FrameObj.SetEndLengthOffset(name, autoLengthOffset.AutoOffset, 0, 0, 0);
                 if (retAutoLEngthOffset != 0)
                 {
                     CreatePropertyWarning("Auto length offset", "Bar", name);
@@ -221,6 +222,7 @@ namespace BH.Adapter.ETABS
                     ret++;
                 }
             }
+
 
             return ret == 0;
         }

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -188,7 +188,7 @@ namespace BH.Adapter.ETABS
                         bhBar.Offset.Start = startLength == 0 ? null : new Vector() { X = startLength * (-1), Y = 0, Z = 0 };
                         bhBar.Offset.End = endLength == 0 ? null : new Vector() { X = endLength, Y = 0, Z = 0 };
                     }
-                    else
+                    else if(rz > 0)
                     {
                         bhBar = bhBar.SetAutoLengthOffset(autoOffset, rz);
                     }

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -178,16 +178,21 @@ namespace BH.Adapter.ETABS
                         bhBar.SectionProperty = property;
                     }
 
-                    //bool autoOffset = false;
-                    //double startLength = 0;
-                    //double endLength = 0;
-                    //double rz = 0;
-                    //model.FrameObj.GetEndLengthOffset(id, ref autoOffset, ref startLength, ref endLength, ref rz);
-                    //if (!autoOffset)
-                    //{
-                    //    bhBar.Offset.Start = startLength == 0 ? null : new Vector() { X = startLength * (-1), Y = 0, Z = 0 };
-                    //    bhBar.Offset.End = endLength == 0 ? null : new Vector() { X = endLength, Y = 0, Z = 0 };
-                    //}
+                    bool autoOffset = false;
+                    double startLength = 0;
+                    double endLength = 0;
+                    double rz = 0;
+                    m_model.FrameObj.GetEndLengthOffset(id, ref autoOffset, ref startLength, ref endLength, ref rz);
+                    if (!autoOffset)
+                    {
+                        bhBar.Offset.Start = startLength == 0 ? null : new Vector() { X = startLength * (-1), Y = 0, Z = 0 };
+                        bhBar.Offset.End = endLength == 0 ? null : new Vector() { X = endLength, Y = 0, Z = 0 };
+                    }
+                    else
+                    {
+                        bhBar = bhBar.SetAutoLengthOffset(autoOffset, rz);
+                    }
+
                     barList.Add(bhBar);
                 }
                 catch


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #140 

 <!-- Add short description of what has been fixed -->
Adding possibility to control RigidZone offset for the Autolength offset.
Adding AutoLengthOffset object in the Etabs_oM to control this.
Changing the previous setter, just setting a boolean, to setting this object as well, with a default RZ-factor of 1.0

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Etabs_Toolkit-Issue140-RigidZoneFactor?csf=1&e=rcgk4W

