### PR TITLE
Etabs toolkit issue135 extract modal mass participation ratios

### DIFF
--- a/Etabs_Adapter/CRUD/ReadResults.cs
+++ b/Etabs_Adapter/CRUD/ReadResults.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.ETABS
             if (typeof(GlobalReactions).IsAssignableFrom(type))
                 return GetGlobalReactions(cases);
             if (typeof(ModalDynamics).IsAssignableFrom(type))
-                throw new NotImplementedException("modal dynamics not supported yet");
+                return GetModalParticipationMassRatios(cases);
 
             return new List<IResult>();
 
@@ -68,6 +68,17 @@ namespace BH.Adapter.ETABS
             return new List<IResult>();
 
         }
+
+        private IEnumerable<IResult> GetModalParticipationMassRatios(IList cases)
+        {
+            IEnumerable<IResult> results = new List<IResult>();
+
+            results = Helper.GetModalParticipationMassRatios(m_model, cases);
+
+            return results;
+
+        }
+
 
         private IEnumerable<IResult> GetObjectResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
         {

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -556,9 +556,7 @@ namespace BH.Adapter.ETABS
             return partRatios;
         }
 
-        #endregion
 
->>>>>>> Stashed changes
     }
 }
 

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -511,6 +511,54 @@ namespace BH.Adapter.ETABS
 
         #endregion
 
+
+        public static List<ModalDynamics> GetModalParticipationMassRatios(cSapModel model, IList cases = null)
+        {
+            List<string> loadcaseIds = new List<string>();
+            List<ModalDynamics> partRatios = new List<ModalDynamics>();
+
+            int resultCount = 0;
+            string[] loadcaseNames = null;
+            string[] stepType = null; double[] stepNum = null;
+            double[] period = null;
+            double[] ux = null; double[] uy = null; double[] uz = null;
+            double[] sumUx = null; double[] sumUy = null; double[] sumUz = null;
+            double[] rx = null; double[] ry = null; double[] rz = null;
+            double[] sumRx = null; double[] sumRy = null; double[] sumRz = null;
+
+            model.Results.ModalParticipatingMassRatios(ref resultCount, ref loadcaseNames, ref stepType, ref stepNum,
+                ref period, ref ux, ref uy, ref uz, ref sumUx, ref sumUy, ref sumUz, ref rx, ref ry, ref rz, ref sumRx, ref sumRy, ref sumRz);
+
+            string previousModalCase = "";
+            int modeNumber = 1;
+
+            for (int i = 0; i < resultCount; i++)
+            {
+                if (loadcaseNames[i] != previousModalCase)
+                    modeNumber = 1;
+
+                ModalDynamics mod = new ModalDynamics()
+                {
+                    ResultCase = loadcaseNames[i],
+                    ModeNumber = modeNumber,
+                    Frequency = 1/period[i],
+                    MassRatioX = ux[i],
+                    MassRatioY = uy[i],
+                    MassRatioZ = uz[i]
+                };
+
+                modeNumber += 1;
+                previousModalCase = loadcaseNames[i];
+
+                partRatios.Add(mod);
+            }
+
+            return partRatios;
+        }
+
+        #endregion
+
+>>>>>>> Stashed changes
     }
 }
 

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -210,7 +210,7 @@ namespace BH.Adapter.ETABS
             throw new NotImplementedException("Node Acceleration results is not supported yet!");
 
         }
-
+        
         #endregion
 
         #region bar Results
@@ -420,9 +420,9 @@ namespace BH.Adapter.ETABS
 
             string Name = "";
             eItemTypeElm ItemTypeElm = eItemTypeElm.ObjectElm;
-            int resultCount = 0;
-            string[] Obj = null;
-            string[] Elm = null;
+	        int resultCount = 0;
+	        string[] Obj = null;
+	        string[] Elm = null;
             string[] PointElm = null;
             string[] LoadCase = null;
             string[] StepType = null;
@@ -447,14 +447,14 @@ namespace BH.Adapter.ETABS
 
             for (int i = 0; i < panelIds.Count; i++)
             {
-
+                
                 int ret = model.Results.AreaForceShell(panelIds[i], eItemTypeElm.ObjectElm, ref resultCount, ref Obj, ref Elm,
                     ref PointElm, ref LoadCase, ref StepType, ref StepNum, ref F11, ref F22, ref F12, ref FMax, ref FMin, ref FAngle, ref FVM,
                     ref M11, ref M22, ref M12, ref MMax, ref MMin, ref MAngle, ref V13, ref V23, ref VMax, ref VAngle);
 
                 for (int j = 0; j < resultCount; j++)
                 {
-                    MeshForce pf = new MeshForce(panelIds[i], PointElm[j], "", LoadCase[j], StepNum[j], 0, 0, 0,
+                    MeshForce pf = new MeshForce(panelIds[i], PointElm[j], "", LoadCase[j], StepNum[j], 0, 0, 0, 
                         new oM.Geometry.CoordinateSystem.Cartesian(), F11[j], F22[j], F12[j], M12[j], M22[j], M12[j], V13[j], V23[j]);
 
                     meshForces.Add(pf);
@@ -477,8 +477,8 @@ namespace BH.Adapter.ETABS
         private static List<string> CheckAndGetCases(cSapModel model, IList cases)
         {
             List<string> loadcaseIds = new List<string>();
-
-            if (cases == null || cases.Count == 0)
+                
+            if (cases == null||cases.Count == 0)
             {
                 int Count = 0;
                 string[] case_names = null;
@@ -487,7 +487,7 @@ namespace BH.Adapter.ETABS
                 model.RespCombo.GetNameList(ref Count, ref combo_names);
                 loadcaseIds = case_names.ToList();
 
-                if (combo_names != null)
+                if(combo_names != null)
                     loadcaseIds.AddRange(combo_names);
             }
             else
@@ -526,28 +526,29 @@ namespace BH.Adapter.ETABS
             double[] rx = null; double[] ry = null; double[] rz = null;
             double[] sumRx = null; double[] sumRy = null; double[] sumRz = null;
 
-            int res = model.Results.ModalParticipatingMassRatios(ref resultCount, ref loadcaseNames, ref stepType, ref stepNum,
+            model.Results.ModalParticipatingMassRatios(ref resultCount, ref loadcaseNames, ref stepType, ref stepNum,
                 ref period, ref ux, ref uy, ref uz, ref sumUx, ref sumUy, ref sumUz, ref rx, ref ry, ref rz, ref sumRx, ref sumRy, ref sumRz);
 
-            if (res != 0)
-                BH.Engine.Reflection.Compute.RecordError("Could not extract Modal information. API method failed.");
-
+            string previousModalCase = "";
+            int modeNumber = 1;
 
             for (int i = 0; i < resultCount; i++)
             {
+                if (loadcaseNames[i] != previousModalCase)
+                    modeNumber = 1;
 
                 ModalDynamics mod = new ModalDynamics()
                 {
                     ResultCase = loadcaseNames[i],
-                    ModeNumber = Convert.ToInt32(stepNum[i]),
-                    Frequency = 1 / period[i],
+                    ModeNumber = modeNumber,
+                    Frequency = 1/period[i],
                     MassRatioX = ux[i],
                     MassRatioY = uy[i],
-                    MassRatioZ = uz[i],
-                    InertiaRatioX = rx[i],
-                    InertiaRatioY = ry[i],
-                    InertiaRatioZ = rz[i]
+                    MassRatioZ = uz[i]
                 };
+
+                modeNumber += 1;
+                previousModalCase = loadcaseNames[i];
 
                 partRatios.Add(mod);
             }

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -210,7 +210,7 @@ namespace BH.Adapter.ETABS
             throw new NotImplementedException("Node Acceleration results is not supported yet!");
 
         }
-        
+
         #endregion
 
         #region bar Results
@@ -420,9 +420,9 @@ namespace BH.Adapter.ETABS
 
             string Name = "";
             eItemTypeElm ItemTypeElm = eItemTypeElm.ObjectElm;
-	        int resultCount = 0;
-	        string[] Obj = null;
-	        string[] Elm = null;
+            int resultCount = 0;
+            string[] Obj = null;
+            string[] Elm = null;
             string[] PointElm = null;
             string[] LoadCase = null;
             string[] StepType = null;
@@ -447,14 +447,14 @@ namespace BH.Adapter.ETABS
 
             for (int i = 0; i < panelIds.Count; i++)
             {
-                
+
                 int ret = model.Results.AreaForceShell(panelIds[i], eItemTypeElm.ObjectElm, ref resultCount, ref Obj, ref Elm,
                     ref PointElm, ref LoadCase, ref StepType, ref StepNum, ref F11, ref F22, ref F12, ref FMax, ref FMin, ref FAngle, ref FVM,
                     ref M11, ref M22, ref M12, ref MMax, ref MMin, ref MAngle, ref V13, ref V23, ref VMax, ref VAngle);
 
                 for (int j = 0; j < resultCount; j++)
                 {
-                    MeshForce pf = new MeshForce(panelIds[i], PointElm[j], "", LoadCase[j], StepNum[j], 0, 0, 0, 
+                    MeshForce pf = new MeshForce(panelIds[i], PointElm[j], "", LoadCase[j], StepNum[j], 0, 0, 0,
                         new oM.Geometry.CoordinateSystem.Cartesian(), F11[j], F22[j], F12[j], M12[j], M22[j], M12[j], V13[j], V23[j]);
 
                     meshForces.Add(pf);
@@ -477,8 +477,8 @@ namespace BH.Adapter.ETABS
         private static List<string> CheckAndGetCases(cSapModel model, IList cases)
         {
             List<string> loadcaseIds = new List<string>();
-                
-            if (cases == null||cases.Count == 0)
+
+            if (cases == null || cases.Count == 0)
             {
                 int Count = 0;
                 string[] case_names = null;
@@ -487,7 +487,7 @@ namespace BH.Adapter.ETABS
                 model.RespCombo.GetNameList(ref Count, ref combo_names);
                 loadcaseIds = case_names.ToList();
 
-                if(combo_names != null)
+                if (combo_names != null)
                     loadcaseIds.AddRange(combo_names);
             }
             else
@@ -526,29 +526,28 @@ namespace BH.Adapter.ETABS
             double[] rx = null; double[] ry = null; double[] rz = null;
             double[] sumRx = null; double[] sumRy = null; double[] sumRz = null;
 
-            model.Results.ModalParticipatingMassRatios(ref resultCount, ref loadcaseNames, ref stepType, ref stepNum,
+            int res = model.Results.ModalParticipatingMassRatios(ref resultCount, ref loadcaseNames, ref stepType, ref stepNum,
                 ref period, ref ux, ref uy, ref uz, ref sumUx, ref sumUy, ref sumUz, ref rx, ref ry, ref rz, ref sumRx, ref sumRy, ref sumRz);
 
-            string previousModalCase = "";
-            int modeNumber = 1;
+            if (res != 0)
+                BH.Engine.Reflection.Compute.RecordError("Could not extract Modal information. API method failed.");
+
 
             for (int i = 0; i < resultCount; i++)
             {
-                if (loadcaseNames[i] != previousModalCase)
-                    modeNumber = 1;
 
                 ModalDynamics mod = new ModalDynamics()
                 {
                     ResultCase = loadcaseNames[i],
-                    ModeNumber = modeNumber,
-                    Frequency = 1/period[i],
+                    ModeNumber = Convert.ToInt32(stepNum[i]),
+                    Frequency = 1 / period[i],
                     MassRatioX = ux[i],
                     MassRatioY = uy[i],
-                    MassRatioZ = uz[i]
+                    MassRatioZ = uz[i],
+                    InertiaRatioX = rx[i],
+                    InertiaRatioY = ry[i],
+                    InertiaRatioZ = rz[i]
                 };
-
-                modeNumber += 1;
-                previousModalCase = loadcaseNames[i];
 
                 partRatios.Add(mod);
             }


### PR DESCRIPTION
 ### Issues addressed by this PR
Added extract modal mass participation ratios. 

Uses `ModalDynamics` class to store the results:

| BHoM `ModalDynamics` | ETABS result |
| --- | --- |
|ResultCase| loadCase name |
| MassRatioX  | ux |
| MassRatioY  | uy |
| MassRatioZ  | uz |
| frequency = `1/p` | period `p` | 

Other results are available from ETABS `ModalParticipatingMassRatios()` that cannot be stored in BHoM `ModalDynamics`: sumUx, SumUy, … (cumulative masses). We can decide if I should update ETABS_toolkit wiki to highlight this or find an alternative.

 Closes #135 

 ### Test files
Grasshopper def: 
https://burohappold.sharepoint.com/:u:/s/BHoM/EfqSLtvvlJZOis4ocRShgfABzA3woSi7Y_3kLk7lMDDLtw?e=M9T4we

ETABS test file folder:
https://burohappold.sharepoint.com/:f:/s/BHoM/Eu29JJpsYvtJvNzE-plZZPwBD5bhiNG_Ojsbr6k_yVlf0Q?e=nsJuEv


 ### Additional comments
The order of the extracted result is not the same as ETABS': mode numbers are randomly sorted, while the order of mode cases is retained. 
Example with 3 different Modal Cases (Modal1, Modal2,Modal3) each with 3 Mode numbers:

|Case name| Mode number | Values (…) |
|---|---|---|
|Modal1| 3 | …|
|Modal1| 1 | …|
|Modal1| 2 | …|
|Modal2| 3 | …|
|Modal2| 2 | …|
|Modal2| 1 | …|
|Modal3| 1 | …|
|Modal3| 2 | …|
|Modal3| 3 | …|

Not sure why this happens or if it can be an issue.

I've set up two sets of Grasshopper panels in the test file to easily compare the extracted results: one set of panels is connected to an Excel table with results extracted from the ETABS model; the other to BHoM's pull.
