### PR TITLE
Etabs toolkit issue135 extract modal mass participation ratios solve branch conflict

### DIFF
--- a/Etabs_Adapter/CRUD/ReadResults.cs
+++ b/Etabs_Adapter/CRUD/ReadResults.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.ETABS
             if (typeof(GlobalReactions).IsAssignableFrom(type))
                 return GetGlobalReactions(cases);
             if (typeof(ModalDynamics).IsAssignableFrom(type))
-                throw new NotImplementedException("modal dynamics not supported yet");
+                return GetModalParticipationMassRatios(cases);
 
             return new List<IResult>();
 

--- a/Etabs_Adapter/CRUD/ReadResults.cs
+++ b/Etabs_Adapter/CRUD/ReadResults.cs
@@ -71,6 +71,17 @@ namespace BH.Adapter.ETABS
 
         }
 
+        private IEnumerable<IResult> GetModalParticipationMassRatios(IList cases)
+        {
+            IEnumerable<IResult> results = new List<IResult>();
+
+            results = Helper.GetModalParticipationMassRatios(m_model, cases);
+
+            return results;
+
+        }
+
+
         private IEnumerable<IResult> GetObjectResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
         {
             IEnumerable<IResult> results = new List<IResult>();


### PR DESCRIPTION
This PR is in lieu of PR #159.

The reason for this is that a conflict didn't allow the merge for #159.

I've copied over the code in this new branch; this PR mirrors that one.

Closes #135.