### PR TITLE
CompatibilityForETABS17Included

### DIFF
--- a/ETABS_Engine/Convert/ToBHoM.cs
+++ b/ETABS_Engine/Convert/ToBHoM.cs
@@ -25,7 +25,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using BH.oM;
 using BH.oM.Structure;
 using BH.oM.Structure.Elements;

--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -12,12 +12,12 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug2016|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;Debug2016</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,6 +28,15 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2017|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;Debug2017</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -45,6 +54,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files\Computers and Structures\ETABS 2016\ETABS2016.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="ETABSv17, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 17\ETABSv17.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>

--- a/ETABS_Engine/ModelData.cs
+++ b/ETABS_Engine/ModelData.cs
@@ -28,7 +28,11 @@
 //using BH.oM.Structure.SectionProperties;
 //using BH.Engine.Structure;
 //using BH.oM.Structure.MaterialFragments;
+//#if (Debug2017)
+//using ETABSv17;
+//#else
 //using ETABS2016;
+//#endif
 
 //namespace BH.Engine.ETABS
 //{

--- a/ETABS_Engine/Query/EtabsShellType.cs
+++ b/ETABS_Engine/Query/EtabsShellType.cs
@@ -22,7 +22,11 @@
 
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Adapters.ETABS;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 
 namespace BH.Engine.ETABS
 {

--- a/ETABS_Test/ETABS_Test.csproj
+++ b/ETABS_Test/ETABS_Test.csproj
@@ -12,14 +12,29 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug2016|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;Debug2016</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -31,6 +46,16 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2017|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;Debug2017</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -62,6 +87,10 @@
     <Reference Include="ETABS2016, Version=16.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files\Computers and Structures\ETABS 2016\ETABS2016.dll</HintPath>
+    </Reference>
+    <Reference Include="ETABSv17, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 17\ETABSv17.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -112,6 +141,18 @@
       <Project>{0f1b6828-633e-420d-bb61-00c16056ba8d}</Project>
       <Name>ETABS_oM</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ETABS_Test/Program.cs
+++ b/ETABS_Test/Program.cs
@@ -36,7 +36,11 @@ using BH.oM.Geometry;
 using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using BH.oM.DataManipulation.Queries;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 
 namespace ETABS_Test
 {
@@ -60,8 +64,13 @@ namespace ETABS_Test
             cSapModel m_model;
 
             cOAPI m_app;
-            string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 2016\ETABS.exe";
-            cHelper helper = new ETABS2016.Helper();
+#if Debug2017
+            string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 17\ETABS.exe";
+            cHelper helper = new ETABSv17.Helper();
+#else
+                string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 2016\ETABS.exe";
+                cHelper helper = new ETABS2016.Helper();
+#endif
 
 
             //open ETABS if not running - NOTE: this behaviour is different from other adapters

--- a/ETABS_Toolkit.sln
+++ b/ETABS_Toolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 14 for Windows Desktop
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.452
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Etabs_Adapter", "Etabs_Adapter\Etabs_Adapter.csproj", "{895E2AB0-E349-4C1A-9098-51A46CD3A955}"
 EndProject
@@ -13,28 +13,40 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETABS_oM", "ETABS_oM\ETABS_
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
+		Debug2016|Any CPU = Debug2016|Any CPU
+		Debug2017|Any CPU = Debug2017|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug2016|Any CPU.ActiveCfg = Debug2016|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug2016|Any CPU.Build.0 = Debug2016|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug2017|Any CPU.ActiveCfg = Debug2017|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug2017|Any CPU.Build.0 = Debug2017|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug2016|Any CPU.ActiveCfg = Debug2016|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug2016|Any CPU.Build.0 = Debug2016|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug2017|Any CPU.ActiveCfg = Debug2017|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug2017|Any CPU.Build.0 = Debug2017|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{72B625AE-519D-4E71-8E91-74146518C5C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{72B625AE-519D-4E71-8E91-74146518C5C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72B625AE-519D-4E71-8E91-74146518C5C2}.Debug2016|Any CPU.ActiveCfg = Debug2016|Any CPU
+		{72B625AE-519D-4E71-8E91-74146518C5C2}.Debug2016|Any CPU.Build.0 = Debug2016|Any CPU
+		{72B625AE-519D-4E71-8E91-74146518C5C2}.Debug2017|Any CPU.ActiveCfg = Debug2017|Any CPU
+		{72B625AE-519D-4E71-8E91-74146518C5C2}.Debug2017|Any CPU.Build.0 = Debug2017|Any CPU
 		{72B625AE-519D-4E71-8E91-74146518C5C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72B625AE-519D-4E71-8E91-74146518C5C2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug2016|Any CPU.ActiveCfg = Debug2016|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug2016|Any CPU.Build.0 = Debug2016|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug2017|Any CPU.ActiveCfg = Debug2017|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug2017|Any CPU.Build.0 = Debug2017|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {73E9AAB8-A011-426D-B63A-39366277C733}
 	EndGlobalSection
 EndGlobal

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug2016|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -29,6 +29,15 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2017|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BHoM">

--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -34,6 +34,11 @@ using BH.Engine.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
+#if Debug2017
+using ETABSv17;
+#else
+using ETABS2016;
+#endif
 
 namespace BH.Adapter.ETABS
 {
@@ -261,32 +266,32 @@ namespace BH.Adapter.ETABS
 
             string propertyName = property2d.Name;// property2d.CustomData[AdapterId].ToString();
 
-            ETABS2016.eShellType shellType = property2d.EtabsShellType();
+            eShellType shellType = property2d.EtabsShellType();
 
             if (property2d.GetType() == typeof(Waffle))
             {
                 Waffle waffleProperty = (Waffle)property2d;
-                m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Waffle, shellType, property2d.Material.Name, waffleProperty.Thickness);
+                m_model.PropArea.SetSlab(propertyName, eSlabType.Waffle, shellType, property2d.Material.Name, waffleProperty.Thickness);
                 retA = m_model.PropArea.SetSlabWaffle(propertyName, waffleProperty.TotalDepthX, waffleProperty.Thickness, waffleProperty.StemWidthX, waffleProperty.StemWidthX, waffleProperty.SpacingX, waffleProperty.SpacingY);
             }
             else if (property2d.GetType() == typeof(Ribbed))
             {
                 Ribbed ribbedProperty = (Ribbed)property2d;
-                m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Ribbed, shellType, property2d.Material.Name, ribbedProperty.Thickness);
+                m_model.PropArea.SetSlab(propertyName, eSlabType.Ribbed, shellType, property2d.Material.Name, ribbedProperty.Thickness);
                 retA = m_model.PropArea.SetSlabRibbed(propertyName, ribbedProperty.TotalDepth, ribbedProperty.Thickness, ribbedProperty.StemWidth, ribbedProperty.StemWidth, ribbedProperty.Spacing, (int)ribbedProperty.Direction);
             }
             else if (property2d.GetType() == typeof(LoadingPanelProperty))
             {
-                retA = m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Slab, shellType, property2d.Material.Name, 0);
+                retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.Name, 0);
             }
 
             else if (property2d.GetType() == typeof(ConstantThickness))
             {
                 ConstantThickness constantThickness = (ConstantThickness)property2d;
                 if (constantThickness.PanelType == PanelType.Wall)
-                    retA = m_model.PropArea.SetWall(propertyName, ETABS2016.eWallPropType.Specified, shellType, property2d.Material.Name, constantThickness.Thickness);
+                    retA = m_model.PropArea.SetWall(propertyName, eWallPropType.Specified, shellType, property2d.Material.Name, constantThickness.Thickness);
                 else
-                    retA = m_model.PropArea.SetSlab(propertyName, ETABS2016.eSlabType.Slab, shellType, property2d.Material.Name, constantThickness.Thickness);
+                    retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.Name, constantThickness.Thickness);
             }
 
 

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -33,7 +33,11 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -29,7 +29,11 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Adapters.ETABS;
+#if Debug2017
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 
 namespace BH.Adapter.ETABS
 {
@@ -63,8 +67,14 @@ namespace BH.Adapter.ETABS
 
                 //string pathToETABS = System.IO.Path.Combine(Environment.GetEnvironmentVariable("PROGRAMFILES"), "Computers and Structures", "ETABS 2016", "ETABS.exe");
                 //string pathToETABS = System.IO.Path.Combine("C:","Program Files", "Computers and Structures", "ETABS 2016", "ETABS.exe");
+#if Debug2017
+                string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 17\ETABS.exe";
+                cHelper helper = new ETABSv17.Helper();
+#else
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 2016\ETABS.exe";
                 cHelper helper = new ETABS2016.Helper();
+#endif
+
 
                 object runningInstance = null;
                 if (System.Diagnostics.Process.GetProcessesByName("ETABS").Length > 0)

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -12,12 +12,12 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug2016|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;Debug2016</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>
@@ -30,6 +30,15 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2017|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;Debug2017</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -64,6 +73,10 @@
       <HintPath>C:\Program Files\Computers and Structures\ETABS 2016\ETABS2016.dll</HintPath>
       <Private>True</Private>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="ETABSv17, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 17\ETABSv17.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>

--- a/Etabs_Adapter/Helpers/LinkConstraints.cs
+++ b/Etabs_Adapter/Helpers/LinkConstraints.cs
@@ -25,7 +25,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using BH.oM.Structure.Loads;
 using BH.oM.Structure;
 using BH.oM.Structure.Constraints;

--- a/Etabs_Adapter/Helpers/Load.cs
+++ b/Etabs_Adapter/Helpers/Load.cs
@@ -25,7 +25,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using BH.oM.Structure.Loads;
 using BH.oM.Structure;
 using BH.oM.Base;

--- a/Etabs_Adapter/Helpers/Material.cs
+++ b/Etabs_Adapter/Helpers/Material.cs
@@ -20,7 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Etabs_Adapter/Helpers/Panel.cs
+++ b/Etabs_Adapter/Helpers/Panel.cs
@@ -25,7 +25,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using BH.oM.Geometry;
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/Helpers/Results.cs
+++ b/Etabs_Adapter/Helpers/Results.cs
@@ -28,7 +28,11 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Common;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using BH.oM.Structure.Elements;
 using BH.oM.Adapters.ETABS.Elements;
 

--- a/Etabs_Adapter/Helpers/Section.cs
+++ b/Etabs_Adapter/Helpers/Section.cs
@@ -25,7 +25,11 @@ using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Structure;
 using CE = BH.Engine.Common;
+#if (Debug2017)
+using ETABSv17;
+#else
 using ETABS2016;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
Ability to build for ETABS2016 or ETABSv17 using the Debug2016 or Debug2017 using the solution configurations dropdown.
Implemented using preprocessor directives as ETABS dll for 2016 has a different name for ETABS 2017.