### PR TITLE
Etabs toolkit issue160 downgrade pull section errors

### DIFF
--- a/Etabs_Adapter/CRUD/Create.cs
+++ b/Etabs_Adapter/CRUD/Create.cs
@@ -107,8 +107,6 @@ namespace BH.Adapter.ETABS
             retA = m_model.PointObj.AddCartesian(position.X, position.Y, position.Z, ref name);
             
             bhNode.CustomData[AdapterId] = name;
-            //if (name != bhId)
-            //    success = false; //this is not necessary if you can guarantee that it is impossible that this bhId does not match any existing name in ETABS !!!
 
             if (bhNode.Support != null)
             {

--- a/Etabs_Adapter/CRUD/Read.cs
+++ b/Etabs_Adapter/CRUD/Read.cs
@@ -300,7 +300,6 @@ namespace BH.Adapter.ETABS
 
             foreach (string id in ids)
             {
-                ISurfaceProperty bhProperty = null;
                 eSlabType slabType = eSlabType.Slab;
                 eShellType shellType = eShellType.ShellThin;
                 eWallPropType wallType = eWallPropType.Specified;

--- a/Etabs_Adapter/Helpers/Load.cs
+++ b/Etabs_Adapter/Helpers/Load.cs
@@ -285,8 +285,6 @@ namespace BH.Adapter.ETABS
 
         public static void SetLoad(cSapModel model, GravityLoad gravityLoad, bool replace)
         {
-            int ret = 0;
-
             double selfWeightMultiplier = 0;
 
             model.LoadPatterns.GetSelfWTMultiplier(CaseNameToCSI(gravityLoad.Loadcase), ref selfWeightMultiplier);

--- a/Etabs_Adapter/Helpers/Section.cs
+++ b/Etabs_Adapter/Helpers/Section.cs
@@ -24,6 +24,7 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Structure;
+using BH.Engine.Reflection;
 using CE = BH.Engine.Common;
 #if (Debug2017)
 using ETABSv17;
@@ -35,7 +36,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Structure.MaterialFragments;
 
 namespace BH.Adapter.ETABS
 {
@@ -184,10 +184,11 @@ namespace BH.Adapter.ETABS
                 case eFramePropType.SteelRod:
                     break;
                 default:
-                    throw new NotImplementedException("Section convertion for the type: " + propertyType.ToString() + " is not implemented in ETABS adapter");
+                    break;
             }
             if(dimensions==null)
-                throw new NotImplementedException("Section convertion for the type: " + propertyType.ToString() + " is not implemented in ETABS adapter");
+                Engine.Reflection.Compute.RecordWarning("Section conversion for the type: " + propertyType.ToString() + " is not implemented in ETABS adapter. A 1m circle has been returned.");
+                dimensions = Engine.Geometry.Create.CircleProfile(1);
             #endregion
 
 
@@ -203,9 +204,9 @@ namespace BH.Adapter.ETABS
                 case "fromDimensions":
                     if (material is Steel || material is Aluminium)
 
-                        bhSectionProperty = Create.SteelSectionFromProfile(dimensions);
+                        bhSectionProperty = Engine.Structure.Create.SteelSectionFromProfile(dimensions);
                     else if (material is Concrete)
-                        bhSectionProperty = Create.ConcreteSectionFromProfile(dimensions);
+                        bhSectionProperty = Engine.Structure.Create.ConcreteSectionFromProfile(dimensions);
                     else
                     {
                         Engine.Reflection.Compute.RecordWarning("Reading sections of material type " + material.GetType().Name + "is not supported. Section with name " + propertyName + " was not pulled");

--- a/Etabs_Adapter/Helpers/Section.cs
+++ b/Etabs_Adapter/Helpers/Section.cs
@@ -197,7 +197,7 @@ namespace BH.Adapter.ETABS
                     break;
             }
             if(dimensions==null)
-                Engine.Reflection.Compute.RecordWarning("Section conversion for the type: " + propertyType.ToString() + " is not implemented in ETABS adapter. An empty section has been returned.");
+                Engine.Reflection.Compute.RecordNote(propertyType.ToString() + " properties are not implemented in ETABS adapter. An empty section has been returned.");
                 constructSelector = "explicit";
             #endregion
 
@@ -219,7 +219,7 @@ namespace BH.Adapter.ETABS
                         bhSectionProperty = Engine.Structure.Create.ConcreteSectionFromProfile(dimensions);
                     else
                     {
-                        Engine.Reflection.Compute.RecordWarning("Reading sections of material type " + material.GetType().Name + "is not supported. Section with name " + propertyName + " was not pulled");
+                        Engine.Reflection.Compute.RecordWarning("Could not create " + propertyType.ToString() + ". Nothing was returned.");
                         return null;
                     }
                     

--- a/Etabs_Adapter/Helpers/Section.cs
+++ b/Etabs_Adapter/Helpers/Section.cs
@@ -72,7 +72,6 @@ namespace BH.Adapter.ETABS
 
             string constructSelector = "fromDimensions";
 
-
             #region long switch on section property type
             switch (propertyType)
             {
@@ -226,26 +225,21 @@ namespace BH.Adapter.ETABS
                     
                     break;
                 case "explicit":
-                    ExplicitSection eSection = new ExplicitSection();
-                    eSection.Area = Area;
-                    eSection.Asy = As2;
-                    eSection.Asz = As3;
-                    //eSection.CentreY = ;
-                    //eSection.CentreZ = ;
-                    //eSection.Iw = 0;//warping
-                    eSection.Iy = I22;
-                    eSection.Iz = I33;
-                    eSection.J = Torsion;
-                    eSection.Rgy = R22;
-                    eSection.Rgz = R33;
-                    eSection.Wply = S22;//capacity - plastic (wply)
-                    eSection.Wplz = S33;
-                    //eSection.Vpy = 0;
-                    //eSection.Vpz = 0;
-                    //eSection.Vy = 0;
-                    //eSection.Vz = 0;
-                    eSection.Wely = Z22;//capacity elastic
-                    eSection.Welz = Z33;
+                    bhSectionProperty = new ExplicitSection()
+                    {
+                        Area = Area,
+                        Asy = As2,
+                        Asz = As3,
+                        Iy = I22,
+                        Iz = I33,
+                        J = Torsion,
+                        Rgy = R22,
+                        Rgz = R33,
+                        Wply = S22,//capacity - plastic (wply)
+                        Wplz = S33,
+                        Wely = Z22,//capacity elastic
+                        Welz = Z33
+                    };
                     break;
                 default:
                     break;

--- a/Etabs_Adapter/Helpers/Section.cs
+++ b/Etabs_Adapter/Helpers/Section.cs
@@ -247,7 +247,7 @@ namespace BH.Adapter.ETABS
 
             bhSectionProperty.Material = material;
             bhSectionProperty.Name = propertyName;
-            bhSectionProperty.CustomData.Add(AdapterId, propertyName);
+            bhSectionProperty.CustomData[AdapterId] = propertyName;
             //modelData.sectionDict.Add(propertyName, bhSectionProperty);
 
             return bhSectionProperty;

--- a/Etabs_Adapter/Helpers/Section.cs
+++ b/Etabs_Adapter/Helpers/Section.cs
@@ -174,21 +174,32 @@ namespace BH.Adapter.ETABS
                     dimensions = Engine.Geometry.Create.TSectionProfile(t2, t2, tw, tf, 0, 0, verticalFlip);
                     break;
                 case eFramePropType.ConcreteBox:
+                    model.PropFrame.GetTube(propertyName, ref fileName, ref materialName, ref t3, ref t2, ref tf, ref tw, ref colour, ref notes, ref guid);
+                    if (tf == tw)
+                        dimensions = Engine.Geometry.Create.BoxProfile(t3, t2, tf, 0, 0);
+                    else
+                        dimensions = Engine.Geometry.Create.FabricatedBoxProfile(t3, t2, tw, tf, tf, 0);
                     break;
                 case eFramePropType.ConcretePipe:
+                    model.PropFrame.GetPipe(propertyName, ref fileName, ref materialName, ref t3, ref tw, ref colour, ref notes, ref guid);
+                    dimensions = Engine.Geometry.Create.TubeProfile(t3, tw);
                     break;
                 case eFramePropType.ConcreteCross:
                     break;
                 case eFramePropType.SteelPlate:
+                    model.PropFrame.GetPlate(propertyName, ref fileName, ref materialName, ref t3, ref t2, ref colour, ref notes, ref guid);
+                    dimensions = Engine.Geometry.Create.RectangleProfile(t3, t2, 0);
                     break;
                 case eFramePropType.SteelRod:
+                    model.PropFrame.GetRod(propertyName, ref fileName, ref materialName, ref t3, ref colour, ref notes, ref guid);
+                    dimensions = Engine.Geometry.Create.CircleProfile(t3);
                     break;
                 default:
                     break;
             }
             if(dimensions==null)
-                Engine.Reflection.Compute.RecordWarning("Section conversion for the type: " + propertyType.ToString() + " is not implemented in ETABS adapter. A 1m circle has been returned.");
-                dimensions = Engine.Geometry.Create.CircleProfile(1);
+                Engine.Reflection.Compute.RecordWarning("Section conversion for the type: " + propertyType.ToString() + " is not implemented in ETABS adapter. An empty section has been returned.");
+                constructSelector = "explicit";
             #endregion
 
 


### PR DESCRIPTION
 ### Issues addressed by this PR
Closes #160 
Closes #194 
Closes #192 

Downgraded read property error to warning, returning an empty explicit section with correct name and material for unsupported sections.
Also, bypassed nextId by setting customData to id returned by ETABS

 ### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Etabs_Toolkit-Issue160-BarPushFailure?csf=1&e=XpKAH1


 ### Changelog
* ETABS_id now set to value assigned in ETABS
* reading bar section property no longer fails on unsupported sections
* pushing bars no longer fails if unsupported sections are defined in ETABS


 ### Additional comments
<!-- As required -->
