### PR TITLE
Updating levels and Grids to target Geometry.SettingOut namespace instead of Architecture namespace

### DIFF
--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -83,6 +83,10 @@
       <HintPath>..\..\BHoM\Build\Analytical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Architecture_oM">
+      <HintPath>..\..\BHoM\Build\Architecture_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
       <Private>False</Private>
@@ -144,6 +148,7 @@
     <Compile Include="Create\Pier.cs" />
     <Compile Include="Create\Spandrel.cs" />
     <Compile Include="ModelData.cs" />
+    <Compile Include="Modify\Upgrade.cs" />
     <Compile Include="Modify\SetAutoLengthOffset.cs" />
     <Compile Include="Modify\SetDiaphragm.cs" />
     <Compile Include="Modify\SetInsertionPoint.cs" />

--- a/ETABS_Engine/Modify/Upgrade.cs
+++ b/ETABS_Engine/Modify/Upgrade.cs
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
+
+namespace BH.Engine.ETABS
+{
+    public static partial class Modify
+    {
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static List<oM.Geometry.SettingOut.Level> UpgradeVersion(this List<BH.oM.Architecture.Elements.Level> levels)
+        {
+            List<oM.Geometry.SettingOut.Level> upgradedLevels = new List<oM.Geometry.SettingOut.Level>();
+
+            foreach (BH.oM.Architecture.Elements.Level level in levels)
+                upgradedLevels.Add(level.UpgradeVersion());
+
+            return upgradedLevels;
+        }
+
+        /***************************************************/
+
+        public static oM.Geometry.SettingOut.Level UpgradeVersion(this BH.oM.Architecture.Elements.Level level)
+        {
+            return new oM.Geometry.SettingOut.Level {
+                Name = level.Name,
+                Elevation = level.Elevation,
+                CustomData = level.CustomData,
+                Fragments = level.Fragments };
+        }
+
+        /***************************************************/
+    }
+}

--- a/ETABS_Toolkit.sln
+++ b/ETABS_Toolkit.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
+# Visual Studio Express 14 for Windows Desktop
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Etabs_Adapter", "Etabs_Adapter\Etabs_Adapter.csproj", "{895E2AB0-E349-4C1A-9098-51A46CD3A955}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETABS_Adapter", "Etabs_Adapter\ETABS_Adapter.csproj", "{895E2AB0-E349-4C1A-9098-51A46CD3A955}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETABS_Engine", "ETABS_Engine\ETABS_Engine.csproj", "{9552D636-D903-4492-944E-0CD392D7BFE3}"
 EndProject

--- a/Etabs_Adapter/Create/Bar.cs
+++ b/Etabs_Adapter/Create/Bar.cs
@@ -22,7 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;

--- a/Etabs_Adapter/Create/Error.cs
+++ b/Etabs_Adapter/Create/Error.cs
@@ -22,7 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;

--- a/Etabs_Adapter/Create/Level.cs
+++ b/Etabs_Adapter/Create/Level.cs
@@ -22,7 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.Engine.ETABS;
 #if Debug17 || Release17
 using ETABSv17;

--- a/Etabs_Adapter/Create/Node.cs
+++ b/Etabs_Adapter/Create/Node.cs
@@ -22,7 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;

--- a/Etabs_Adapter/Create/Panel.cs
+++ b/Etabs_Adapter/Create/Panel.cs
@@ -22,7 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;

--- a/Etabs_Adapter/Create/_Create.cs
+++ b/Etabs_Adapter/Create/_Create.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Geometry.SettingOut;
+using BH.oM.Architecture.Elements;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
@@ -82,9 +83,15 @@ namespace BH.Adapter.ETABS
                 this.Replace(diaphragms);
             }
 
-            if (typeof(T) == typeof(Level))
+            if (typeof(T) == typeof(oM.Geometry.SettingOut.Level))
             {
-                return CreateCollection(objects as IEnumerable<Level>);
+                return CreateCollection(objects as IEnumerable<oM.Geometry.SettingOut.Level>);
+            }
+            else if(typeof(T) == typeof(oM.Architecture.Elements.Level))
+            {
+                List<oM.Geometry.SettingOut.Level> levels = (objects as List<oM.Architecture.Elements.Level>).UpgradeVersion();
+
+                return CreateCollection(levels as IEnumerable<oM.Geometry.SettingOut.Level>);
             }
             else
             {
@@ -97,5 +104,6 @@ namespace BH.Adapter.ETABS
         }
         
         /***************************************************/
+
     }
 }

--- a/Etabs_Adapter/Create/_Create.cs
+++ b/Etabs_Adapter/Create/_Create.cs
@@ -89,7 +89,7 @@ namespace BH.Adapter.ETABS
             }
             else if(typeof(T) == typeof(oM.Architecture.Elements.Level))
             {
-                List<oM.Geometry.SettingOut.Level> levels = (objects as List<oM.Architecture.Elements.Level>).UpgradeVersion();
+                List<oM.Geometry.SettingOut.Level> levels = objects.Select(x => (x as oM.Architecture.Elements.Level).UpgradeVersion()).ToList();
 
                 return CreateCollection(levels as IEnumerable<oM.Geometry.SettingOut.Level>);
             }

--- a/Etabs_Adapter/Create/_Create.cs
+++ b/Etabs_Adapter/Create/_Create.cs
@@ -22,7 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;

--- a/Etabs_Adapter/Read/Level.cs
+++ b/Etabs_Adapter/Read/Level.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 #if Debug17 || Release17
 using ETABSv17;
 #else

--- a/Etabs_Adapter/Read/Material.cs
+++ b/Etabs_Adapter/Read/Material.cs
@@ -42,7 +42,7 @@ using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/Read/Mesh.cs
+++ b/Etabs_Adapter/Read/Mesh.cs
@@ -42,7 +42,7 @@ using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/Read/Node.cs
+++ b/Etabs_Adapter/Read/Node.cs
@@ -42,7 +42,7 @@ using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/Read/Panel.cs
+++ b/Etabs_Adapter/Read/Panel.cs
@@ -37,7 +37,7 @@ using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Adapters.ETABS.Elements;
 
 #if Debug17 || Release17

--- a/Etabs_Adapter/Read/_Read.cs
+++ b/Etabs_Adapter/Read/_Read.cs
@@ -43,6 +43,7 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
 using BH.oM.Geometry.SettingOut;
+using BH.oM.Architecture.Elements;
 using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
@@ -81,7 +82,7 @@ namespace BH.Adapter.ETABS
                 return ReadRigidLink(ids as dynamic);
             else if (type == typeof(LinkConstraint))
                 return ReadLinkConstraints(ids as dynamic);
-            else if (type == typeof(Level))
+            else if (type == typeof(oM.Geometry.SettingOut.Level) || type == typeof(oM.Architecture.Elements.Level))
                 return ReadLevel(ids as dynamic);
             else if (type == typeof(FEMesh))
                 return ReadMesh(ids as dynamic);

--- a/Etabs_Adapter/Read/_Read.cs
+++ b/Etabs_Adapter/Read/_Read.cs
@@ -42,7 +42,7 @@ using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #207 

Replaced mention of oM.Architecture with oM.Geometry.SettingOut


 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/PR_208-UpdateGridAndLevel?csf=1&e=ew2hP8

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
