### PR TITLE
Etabs18 included

### DIFF
--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -77,6 +77,26 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|AnyCPU'">
+    <OutputPath>bin\Debug18\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release18|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Release18\</OutputPath>
+    <DefineConstants>TRACE;Release18</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -90,6 +110,9 @@
     <Reference Include="Common_oM">
       <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="ETABSv1">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 18\ETABSv1.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>

--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -78,7 +78,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|AnyCPU'">
-    <OutputPath>bin\Debug18\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -89,7 +89,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release18|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Release18\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE;Release18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ETABS_Toolkit.sln
+++ b/ETABS_Toolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29324.140
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Etabs_Adapter", "Etabs_Adapter\Etabs_Adapter.csproj", "{895E2AB0-E349-4C1A-9098-51A46CD3A955}"
 EndProject
@@ -14,9 +14,11 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Debug16|Any CPU = Debug16|Any CPU
 		Debug17|Any CPU = Debug17|Any CPU
+		Debug18|Any CPU = Debug18|Any CPU
 		Release|Any CPU = Release|Any CPU
 		Release16|Any CPU = Release16|Any CPU
 		Release17|Any CPU = Release17|Any CPU
+		Release18|Any CPU = Release18|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -25,36 +27,48 @@ Global
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug16|Any CPU.Build.0 = Debug16|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug17|Any CPU.ActiveCfg = Debug17|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug17|Any CPU.Build.0 = Debug17|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|Any CPU.ActiveCfg = Debug18|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|Any CPU.Build.0 = Debug18|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release|Any CPU.Build.0 = Release|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release16|Any CPU.ActiveCfg = Release16|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release16|Any CPU.Build.0 = Release16|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release17|Any CPU.ActiveCfg = Release17|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release17|Any CPU.Build.0 = Release17|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release18|Any CPU.ActiveCfg = Release18|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release18|Any CPU.Build.0 = Release18|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug16|Any CPU.ActiveCfg = Debug16|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug16|Any CPU.Build.0 = Debug16|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug17|Any CPU.ActiveCfg = Debug17|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug17|Any CPU.Build.0 = Debug17|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug18|Any CPU.ActiveCfg = Debug18|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Debug18|Any CPU.Build.0 = Debug18|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release16|Any CPU.ActiveCfg = Release16|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release16|Any CPU.Build.0 = Release16|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release17|Any CPU.ActiveCfg = Release17|Any CPU
 		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release17|Any CPU.Build.0 = Release17|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release18|Any CPU.ActiveCfg = Release18|Any CPU
+		{9552D636-D903-4492-944E-0CD392D7BFE3}.Release18|Any CPU.Build.0 = Release18|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug16|Any CPU.ActiveCfg = Debug17|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug16|Any CPU.Build.0 = Debug17|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug17|Any CPU.ActiveCfg = Debug17|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug17|Any CPU.Build.0 = Debug17|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug18|Any CPU.ActiveCfg = Debug18|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Debug18|Any CPU.Build.0 = Debug18|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release16|Any CPU.ActiveCfg = Release16|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release16|Any CPU.Build.0 = Release16|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release17|Any CPU.ActiveCfg = Release17|Any CPU
 		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release17|Any CPU.Build.0 = Release17|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release18|Any CPU.ActiveCfg = Release18|Any CPU
+		{0F1B6828-633E-420D-BB61-00C16056BA8D}.Release18|Any CPU.Build.0 = Release18|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -80,7 +80,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|AnyCPU'">
-    <OutputPath>bin\Debug18\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -91,7 +91,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release18|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Release18\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE;Release18</DefineConstants>
     <WarningLevel>0</WarningLevel>
     <DebugType>full</DebugType>

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -79,6 +79,27 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|AnyCPU'">
+    <OutputPath>bin\Debug18\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release18|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Release18\</OutputPath>
+    <DefineConstants>TRACE;Release18</DefineConstants>
+    <WarningLevel>0</WarningLevel>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
@@ -87,6 +108,9 @@
     <Reference Include="Common_oM">
       <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="ETABSv1">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 18\ETABSv1.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_oM">
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>

--- a/Etabs_Adapter/Create/Bar.cs
+++ b/Etabs_Adapter/Create/Bar.cs
@@ -43,7 +43,9 @@ using BH.oM.Geometry.ShapeProfiles;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/Error.cs
+++ b/Etabs_Adapter/Create/Error.cs
@@ -34,15 +34,20 @@ using BH.Engine.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
 #endif
 
+
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/Level.cs
+++ b/Etabs_Adapter/Create/Level.cs
@@ -24,7 +24,9 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Architecture.Elements;
 using BH.Engine.ETABS;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -32,7 +34,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/Link.cs
+++ b/Etabs_Adapter/Create/Link.cs
@@ -24,15 +24,21 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
 #endif
 
+
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter
@@ -101,11 +107,8 @@ namespace BH.Adapter.ETABS
 
         public override string ToString()
         {
-#if Debug17 || Release17
-    return base.ToString();
-#else
+
             return base.ToString();
-#endif
 
         }
 

--- a/Etabs_Adapter/Create/Load.cs
+++ b/Etabs_Adapter/Create/Load.cs
@@ -27,7 +27,9 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
 using BH.Engine.ETABS;
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -35,7 +37,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/Material.cs
+++ b/Etabs_Adapter/Create/Material.cs
@@ -26,7 +26,9 @@ using BH.Engine.Structure;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -34,7 +36,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/Node.cs
+++ b/Etabs_Adapter/Create/Node.cs
@@ -38,7 +38,9 @@ using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/Panel.cs
+++ b/Etabs_Adapter/Create/Panel.cs
@@ -35,7 +35,9 @@ using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -43,7 +45,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Create/_Create.cs
+++ b/Etabs_Adapter/Create/_Create.cs
@@ -34,7 +34,9 @@ using BH.Engine.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -42,7 +44,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Delete/_Delete.cs
+++ b/Etabs_Adapter/Delete/_Delete.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -78,17 +78,7 @@ namespace BH.Adapter.ETABS
                 Config.ProcessInMemory = false;
                 Config.CloneBeforePush = true;
 
-                //string pathToETABS = System.IO.Path.Combine(Environment.GetEnvironmentVariable("PROGRAMFILES"), "Computers and Structures", "ETABS 2016", "ETABS.exe");
-                //string pathToETABS = System.IO.Path.Combine("C:","Program Files", "Computers and Structures", "ETABS 2016", "ETABS.exe");
-#if Debug18 || Release18
-                string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 18\ETABS.exe";                
-#elif Debug17 || Release17
-                string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 17\ETABS.exe";
 
-#else
-                string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 2016\ETABS.exe";
-
-#endif
                 cHelper helper = new Helper();
 
                 object runningInstance = null;
@@ -105,7 +95,7 @@ namespace BH.Adapter.ETABS
                 else
                 {
                     //open ETABS if not running - NOTE: this behaviour is different from other adapters
-                    m_app = helper.CreateObject(pathToETABS);
+                    m_app = helper.CreateObjectProgID("CSI.ETABS.API.ETABSObject");
                     m_app.ApplicationStart();
                     m_model = m_app.SapModel;
                     m_model.InitializeNewModel(eUnits.N_m_C);

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -29,7 +29,9 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Adapters.ETABS;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -37,7 +39,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter
@@ -55,7 +59,9 @@ namespace BH.Adapter.ETABS
         /**** Constructors                              ****/
         /***************************************************/
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+        public ETABS18Adapter(string filePath = "", EtabsConfig etabsConfig = null, bool active = false)
+#elif Debug17 || Release17
         public ETABS17Adapter(string filePath = "", EtabsConfig etabsConfig = null, bool active = false)
 #else
         public ETABS2016Adapter(string filePath = "", EtabsConfig etabsConfig = null, bool active = false)
@@ -74,14 +80,16 @@ namespace BH.Adapter.ETABS
 
                 //string pathToETABS = System.IO.Path.Combine(Environment.GetEnvironmentVariable("PROGRAMFILES"), "Computers and Structures", "ETABS 2016", "ETABS.exe");
                 //string pathToETABS = System.IO.Path.Combine("C:","Program Files", "Computers and Structures", "ETABS 2016", "ETABS.exe");
-#if Debug17 || Release17
+#if Debug18 || Release18
+                string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 18\ETABS.exe";                
+#elif Debug17 || Release17
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 17\ETABS.exe";
-                cHelper helper = new ETABSv17.Helper();
+
 #else
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 2016\ETABS.exe";
-                cHelper helper = new ETABS2016.Helper();
-#endif
 
+#endif
+                cHelper helper = new Helper();
 
                 object runningInstance = null;
                 if (System.Diagnostics.Process.GetProcessesByName("ETABS").Length > 0)

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.ETABS</RootNamespace>
-    <AssemblyName>Etabs_Adapter2016</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -19,7 +18,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.ETABS</RootNamespace>
-    <AssemblyName>ETABS17_Adapter</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -30,7 +28,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.ETABS</RootNamespace>
-    <AssemblyName>Etabs_Adapter2016</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -41,7 +38,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.ETABS</RootNamespace>
-    <AssemblyName>ETABS17_Adapter</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -53,7 +49,6 @@
     <DefineConstants>TRACE;DEBUG;Debug16</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AssemblyName>Etabs2016_Adapter</AssemblyName>
     <DocumentationFile>
     </DocumentationFile>
   </PropertyGroup>
@@ -65,7 +60,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>ETABS17_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release16|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -75,7 +69,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>Etabs2016_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release17|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -85,7 +78,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>ETABS17_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -95,7 +87,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>Etabs2016_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -105,26 +96,27 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>Etabs2016_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug18\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release18|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Release18\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE;Release18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -107,6 +107,26 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyName>Etabs2016_Adapter</AssemblyName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug18\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release18|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Release18\</OutputPath>
+    <DefineConstants>TRACE;Release18</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -139,10 +159,16 @@
       <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="ETABS">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 18\ETABS.exe</HintPath>
+    </Reference>
     <Reference Include="ETABS2016, Version=16.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CSI_ETABSv2016_x64.1.0.3\lib\ETABS2016.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="ETABSv1">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 18\ETABSv1.dll</HintPath>
     </Reference>
     <Reference Include="ETABSv17, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CSI_ETABSv17_x64.1.0.3\lib\ETABSv17.dll</HintPath>
@@ -239,6 +265,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Etabs_Adapter/Read/Bar.cs
+++ b/Etabs_Adapter/Read/Bar.cs
@@ -33,7 +33,9 @@ using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 using BH.oM.Geometry;
 using BH.oM.Geometry.ShapeProfiles;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -41,7 +43,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Level.cs
+++ b/Etabs_Adapter/Read/Level.cs
@@ -27,7 +27,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Architecture.Elements;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -35,7 +37,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Link.cs
+++ b/Etabs_Adapter/Read/Link.cs
@@ -29,15 +29,20 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
 #endif
 
+
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Load.cs
+++ b/Etabs_Adapter/Read/Load.cs
@@ -31,7 +31,9 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
 using BH.Engine.ETABS;
 using BH.oM.Geometry;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -39,7 +41,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Material.cs
+++ b/Etabs_Adapter/Read/Material.cs
@@ -33,7 +33,9 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -47,7 +49,9 @@ using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Mesh.cs
+++ b/Etabs_Adapter/Read/Mesh.cs
@@ -33,7 +33,9 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -47,7 +49,9 @@ using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Node.cs
+++ b/Etabs_Adapter/Read/Node.cs
@@ -33,7 +33,9 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -47,7 +49,9 @@ using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Panel.cs
+++ b/Etabs_Adapter/Read/Panel.cs
@@ -40,7 +40,9 @@ using BH.Engine.Reflection;
 using BH.oM.Architecture.Elements;
 using BH.oM.Adapters.ETABS.Elements;
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -48,7 +50,9 @@ using ETABS2016;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/Result.cs
+++ b/Etabs_Adapter/Read/Result.cs
@@ -28,7 +28,9 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Common;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -40,7 +42,9 @@ using BH.oM.Structure.Loads;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Read/_Read.cs
+++ b/Etabs_Adapter/Read/_Read.cs
@@ -33,7 +33,9 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;
@@ -47,7 +49,9 @@ using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Types/Comparer.cs
+++ b/Etabs_Adapter/Types/Comparer.cs
@@ -34,7 +34,9 @@ using BH.Engine.Base.Objects;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Types/DependencyTypes.cs
+++ b/Etabs_Adapter/Types/DependencyTypes.cs
@@ -31,7 +31,9 @@ using System.Collections.Generic;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Types/NextIndex.cs
+++ b/Etabs_Adapter/Types/NextIndex.cs
@@ -28,7 +28,9 @@ using System.Threading.Tasks;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/Update/_Update.cs
+++ b/Etabs_Adapter/Update/_Update.cs
@@ -34,7 +34,9 @@ using BH.oM.Adapters.ETABS.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
+#if Debug18 || Release18
+    public partial class ETABS18Adapter : BHoMAdapter
+#elif Debug17 || Release17
     public partial class ETABS17Adapter : BHoMAdapter
 #else
     public partial class ETABS2016Adapter : BHoMAdapter

--- a/Etabs_Adapter/_Engine/Convert/ToBHoM.cs
+++ b/Etabs_Adapter/_Engine/Convert/ToBHoM.cs
@@ -29,7 +29,9 @@ using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.Constraints;
 using BH.Adapter.ETABS;
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;

--- a/Etabs_Adapter/_Engine/Convert/ToCSI.cs
+++ b/Etabs_Adapter/_Engine/Convert/ToCSI.cs
@@ -26,7 +26,9 @@ using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry;
 
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;

--- a/Etabs_Adapter/_Engine/Query/EtabsShellType.cs
+++ b/Etabs_Adapter/_Engine/Query/EtabsShellType.cs
@@ -22,7 +22,9 @@
 
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Adapters.ETABS;
-#if Debug17 || Release17
+#if Debug18 || Release18
+using ETABSv1;
+#elif Debug17 || Release17
 using ETABSv17;
 #else
 using ETABS2016;

--- a/Etabs_Adapter/packages.config
+++ b/Etabs_Adapter/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CSI_ETABSv17_x64" version="1.0.3" targetFramework="net452" />
+  <package id="CSI_ETABSv18_x64" version="1.0.0" targetFramework="net452" />
   <package id="CSI_ETABSv2016_x64" version="1.0.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
 ### Issues addressed by this PR

Added functionality for ETABS18.

 Closes #

N/A

 ### Test files

N/A


 ### Changelog

N/A

 ### Additional comments
ETABS18 (v1 of the API) requires .Net Framework 4.7.1 or higher to run so for builds of Release18 and Debug18 the target framework is changed to 4.7.2 (this version was chosen to be in line with a similar issue found in the Revit adapter).  For all other build versions, the compiler still targets 4.5.2.
