### PR TITLE
Aligning with changes in BHoMAdapter

### DIFF
--- a/Etabs_Adapter/Create/_Create.cs
+++ b/Etabs_Adapter/Create/_Create.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.ETABS
     {
 
         /***************************************************/
-        protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false)
+        protected override bool Create<T>(IEnumerable<T> objects)
         {
             bool success = true;
 
@@ -80,7 +80,7 @@ namespace BH.Adapter.ETABS
 
                 List<Diaphragm> diaphragms = panels.Select(x => x.Diaphragm()).Where(x => x != null).ToList();
 
-                this.Replace(diaphragms);
+                this.CRUD(diaphragms);
             }
 
             if (typeof(T) == typeof(oM.Geometry.SettingOut.Level))

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -67,11 +67,6 @@ namespace BH.Adapter.ETABS
 
                 this.EtabsConfig = etabsConfig == null ? new EtabsConfig() : etabsConfig;
 
-                Config.SeparateProperties = true;
-                Config.MergeWithComparer = true;
-                Config.ProcessInMemory = false;
-                Config.CloneBeforePush = true;
-
                 //string pathToETABS = System.IO.Path.Combine(Environment.GetEnvironmentVariable("PROGRAMFILES"), "Computers and Structures", "ETABS 2016", "ETABS.exe");
                 //string pathToETABS = System.IO.Path.Combine("C:","Program Files", "Computers and Structures", "ETABS 2016", "ETABS.exe");
 #if Debug17 || Release17


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM_Adapter/pull/151

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #222

 <!-- Add short description of what has been fixed -->

Updating adapter to align with changes in the parent BHoMAdapter

 ### Test files
<!-- Link to test files to validate the proposed changes -->

All previous scripts should still be working as before.

Link to macro testfiles:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/_Macro/Push?csf=1&e=84ibrL

 ### Additional comments
<!-- As required -->