### PR TITLE
Update names of MeshResult classes

### DIFF
--- a/Etabs_Adapter/Read/Result.cs
+++ b/Etabs_Adapter/Read/Result.cs
@@ -83,7 +83,7 @@ namespace BH.Adapter.ETABS
                 results = GetNodeResults(type, ids, cases);
             else if (typeof(BarResult).IsAssignableFrom(type))
                 results = GetBarResults(type, ids, cases, divisions);
-            else if (typeof(MeshResult).IsAssignableFrom(type))
+            else if (typeof(MeshElementResult).IsAssignableFrom(type))
                 results = GetMeshResults(type, ids, cases, divisions);
             //else
             //    return new List<IResult>();
@@ -133,7 +133,7 @@ namespace BH.Adapter.ETABS
 
         private IEnumerable<IResult> GetMeshResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
         {
-            IEnumerable<MeshResult> results = new List<MeshResult>();
+            IEnumerable<MeshElementResult> results = new List<MeshElementResult>();
 
             if (type == typeof(MeshForce))
                 results = GetMeshForce(ids, cases, divisions);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/611

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #226 

 <!-- Add short description of what has been fixed -->

Updating namings of MeshResult classes. Additional refactoring to make use of the ResultCollections to be done together with updates to result extractions in here https://github.com/BHoM/ETABS_Toolkit/issues/227

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/ErV6ZcpsxlxGsQam9LUokNcBpJM3GEzBrpEpZcGtdlyndA?e=7b0yu5

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Update namings of MeshResults

 ### Additional comments
<!-- As required -->
