### PR TITLE
Error-handling when pushing sections

### DIFF
--- a/Etabs_Adapter/Create/Bar.cs
+++ b/Etabs_Adapter/Create/Bar.cs
@@ -204,22 +204,6 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
-        private void SetSection(CableSection section)
-        {
-            //no ISectionDimentions
-            CreateElementError("Section Profile", section.Name);
-        }
-
-        /***************************************************/
-
-        private void SetSection(CompositeSection section)
-        {
-            //contains SteelSection and ConcreteScetion
-            CreateElementError("Section Profile", section.Name);
-        }
-
-        /***************************************************/
-
         private void SetSection(ExplicitSection section)
         {
             m_model.PropFrame.SetGeneral(section.Name, section.Material.Name, section.CentreZ * 2, section.CentreY * 2, section.Area, section.Asy, section.Asz, section.J, section.Iy, section.Iz, section.Wply, section.Wplz, section.Wely, section.Wely, section.Rgy, section.Rgz);
@@ -322,20 +306,6 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
-        private void SetProfile(ZSectionProfile profile, string sectionName, IMaterialFragment material)
-        {
-            Engine.Reflection.Compute.RecordWarning("Z-Section currently not supported in the ETABS adapter. Section with name " + sectionName + " has not been pushed.");
-        }
-
-        /***************************************************/
-
-        private void SetProfile(GeneralisedTSectionProfile profile, string sectionName, IMaterialFragment material)
-        {
-            Engine.Reflection.Compute.RecordWarning("GeneralisedTSectionProfile currently not supported in the ETABS adapter. Section with name " + sectionName + " has not been pushed.");
-        }
-
-        /***************************************************/
-
         private void SetProfile(RectangleProfile profile, string sectionName, IMaterialFragment material)
         {
             m_model.PropFrame.SetRectangle(sectionName, material.Name, profile.Height, profile.Width);
@@ -346,13 +316,6 @@ namespace BH.Adapter.ETABS
         private void SetProfile(CircleProfile profile, string sectionName, IMaterialFragment material)
         {
             m_model.PropFrame.SetCircle(sectionName, material.Name, profile.Diameter);
-        }
-
-        /***************************************************/
-
-        private void SetProfile(FreeFormProfile profile, string sectionName, IMaterialFragment material)
-        {
-            CreateElementError("Section Profile", sectionName);
         }
 
         /***************************************************/

--- a/Etabs_Adapter/Create/Bar.cs
+++ b/Etabs_Adapter/Create/Bar.cs
@@ -185,14 +185,14 @@ namespace BH.Adapter.ETABS
 
         private void SetSection(SteelSection section)
         {
-            SetProfile(section.SectionProfile, section.Name, section.Material);
+            ISetProfile(section.SectionProfile, section.Name, section.Material);
         }
 
         /***************************************************/
 
         private void SetSection(ConcreteSection section)
         {
-            SetProfile(section.SectionProfile, section.Name, section.Material);
+            ISetProfile(section.SectionProfile, section.Name, section.Material);
         }
 
         /***************************************************/
@@ -220,9 +220,16 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
-        private void SetProfile(IProfile sectionProfile, string sectionName, IMaterialFragment material)
+        private void ISetProfile(IProfile sectionProfile, string sectionName, IMaterialFragment material)
         {
-            SetProfile(sectionProfile as dynamic, sectionName, material);
+            try
+            {
+                SetProfile(sectionProfile as dynamic, sectionName, material);
+            }
+            catch
+            {
+                CreateElementError(sectionProfile.GetType().ToString(), sectionName);
+            }
         }
 
         /***************************************************/
@@ -311,6 +318,13 @@ namespace BH.Adapter.ETABS
         private void SetProfile(ZSectionProfile profile, string sectionName, IMaterialFragment material)
         {
             Engine.Reflection.Compute.RecordWarning("Z-Section currently not supported in the ETABS adapter. Section with name " + sectionName + " has not been pushed.");
+        }
+
+        /***************************************************/
+
+        private void SetProfile(GeneralisedTSectionProfile profile, string sectionName, IMaterialFragment material)
+        {
+            Engine.Reflection.Compute.RecordWarning("GeneralisedTSectionProfile currently not supported in the ETABS adapter. Section with name " + sectionName + " has not been pushed.");
         }
 
         /***************************************************/

--- a/Etabs_Adapter/Create/Bar.cs
+++ b/Etabs_Adapter/Create/Bar.cs
@@ -158,7 +158,14 @@ namespace BH.Adapter.ETABS
                 return true;
             }
 
-            SetSection(bhSection as dynamic);
+            try
+            {
+                SetSection(bhSection as dynamic);
+            }
+            catch
+            {
+                CreateElementError(bhSection.GetType().ToString(), bhSection.Name);
+            }
 
             double[] modifiers = bhSection.Modifiers();
 

--- a/Etabs_Adapter/Create/Bar.cs
+++ b/Etabs_Adapter/Create/Bar.cs
@@ -158,14 +158,7 @@ namespace BH.Adapter.ETABS
                 return true;
             }
 
-            try
-            {
-                SetSection(bhSection as dynamic);
-            }
-            catch
-            {
-                CreateElementError(bhSection.GetType().ToString(), bhSection.Name);
-            }
+            SetSection(bhSection as dynamic);
 
             double[] modifiers = bhSection.Modifiers();
 
@@ -211,16 +204,16 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
+        private void SetSection(ISectionProperty section)
+        {
+            CreateElementError(section.GetType().ToString(), section.Name);
+        }
+
+        /***************************************************/
+
         private void ISetProfile(IProfile sectionProfile, string sectionName, IMaterialFragment material)
         {
-            try
-            {
-                SetProfile(sectionProfile as dynamic, sectionName, material);
-            }
-            catch
-            {
-                CreateElementError(sectionProfile.GetType().ToString(), sectionName);
-            }
+            SetProfile(sectionProfile as dynamic, sectionName, material);
         }
 
         /***************************************************/
@@ -316,6 +309,13 @@ namespace BH.Adapter.ETABS
         private void SetProfile(CircleProfile profile, string sectionName, IMaterialFragment material)
         {
             m_model.PropFrame.SetCircle(sectionName, material.Name, profile.Diameter);
+        }
+
+        /***************************************************/
+
+        private void SetProfile(IProfile profile, string sectionName, IMaterialFragment material)
+        {
+            CreateElementError(profile.GetType().ToString(), sectionName);
         }
 
         /***************************************************/


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #213 
 <!-- Add short description of what has been fixed -->
Separated `SetProfile` into a `ISetProfile` interface method as well and added some try catch, while removing the now unnecessary methods for un-implemented sections.
Previously it got stuck in an infinite loop if the exact section wasn't present among the specific methods

 ### Test files
<!-- Link to test files to validate the proposed changes -->
Note: without this branch rhino will crash when you push, so don't do this in an instance of rhino with unsaved work
https://burohappold.sharepoint.com/:u:/s/BHoM/EU6TKtHLe0FJmZyiuOxbOb8BQOuyrnY2YTC3tNrHBIPG5Q?e=fvwgwB

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments

