### PR TITLE
BarVaryingDistributedLoad Extent Fix

### DIFF
--- a/Etabs_Adapter/Create/Load.cs
+++ b/Etabs_Adapter/Create/Load.cs
@@ -26,6 +26,7 @@ using System;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
 using BH.Engine.ETABS;
+using BH.Engine.Common;
 
 #if Debug17 || Release17
 using ETABSv17;
@@ -201,7 +202,7 @@ namespace BH.Adapter.ETABS
                     double val1 = barLoad.ForceA.Z; //note: etabs acts different then stated in API documentstion
                     double val2 = barLoad.ForceB.Z;
                     double dist1 = barLoad.DistanceFromA;
-                    double dist2 = barLoad.DistanceFromB;
+                    double dist2 = bar.Length() - barLoad.DistanceFromB;
                     string caseName = barLoad.Loadcase.CustomData[AdapterId].ToString();
                     string nodeName = bar.CustomData[AdapterId].ToString();
                     int direction = 6; // we're doing this for Z axis only right now.


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #177 
The distance from j is now defined as the distance from i in the `Create`. Which is how ETABS want it to be defined

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/ES3dN21bPLVPgeRB5F4k3ycBF5C8hSC5kPQNxrTAfV-w2g?e=diVrCV

 ### Changelog

 ### Additional comments
<!-- As required -->