### PR TITLE
Fixing material density pushed with wrong "option" 

### DIFF
--- a/Etabs_Adapter/Create/Material.cs
+++ b/Etabs_Adapter/Create/Material.cs
@@ -67,7 +67,7 @@ namespace BH.Adapter.ETABS
                     double[] g = orthoTropic.ShearModulus.ToDoubleArray();
                     m_model.PropMaterial.SetMPOrthotropic(material.Name, ref e, ref v, ref a, ref g);
                 }
-                m_model.PropMaterial.SetWeightAndMass(material.Name, 0, material.Density);
+                m_model.PropMaterial.SetWeightAndMass(material.Name, 2, material.Density);
             }
 
             return true;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #240 

 <!-- Add short description of what has been fixed -->

Material density had wrong option in push leading to values coming over slightly skewed

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/_Macro/Push?csf=1&e=vU1hVJ

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
