### PR TITLE
Push/Pull sections with Tapered Profile

### DIFF
--- a/Etabs_Adapter/CRUD/Create/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SectionProperty.cs
@@ -166,8 +166,9 @@ namespace BH.Adapter.ETABS
 
             // Some array settings
             int[] type = length.Select(x => 1).ToArray<int>(); // Relative Length values, (No idea what happens or why someone would mix thease)
-            int[] eI33 = length.Select(x => 2).ToArray<int>(); // Parabolic variation of EI33
-            int[] eI22 = length.Select(x => 1).ToArray<int>(); // Linear variation of EI22      Default when opening ETABS
+            int[] eI33 = length.Select(x => 1).ToArray<int>(); // Linear variation of EI33
+            int[] eI22 = length.Select(x => 1).ToArray<int>(); // Linear variation of EI22
+            Engine.Reflection.Compute.RecordNote("Tapered Sections Properties are set to vary linearly along the element in ETABS.");
 
             int rA = m_model.PropFrame.SetNonPrismatic(sectionName, num, ref segmentStartProfile, ref segmentEndProfile, ref length, ref type, ref eI33, ref eI22);
         }

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -224,7 +224,7 @@ namespace BH.Adapter.ETABS
                                 else if (materialName != sec.Material.Name)
                                 {
                                     materialName = "";
-                                    Engine.Reflection.Compute.RecordWarning("All sub sections must have the same meterial.");
+                                    Engine.Reflection.Compute.RecordWarning("All sub-sections must have the same material.");
                                     break;
                                 }
                             }


### PR DESCRIPTION

 ### Issues addressed by this PR

 Closes #290
as title

looks worse than it is, I placed a loop around the section reading to always get the tapered sections last, as they needed the sub sections to have been read beforehand.
Not sure a loop is the pretties way (as it only ever runs twice) so welcome to suggestions.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
You will notice that a lot of the pulled sections are explicit, that is as it appears that ETABS does not have a read for T-sections, a more formal check on what's missing there might be worth it @IsakNaslundBh 
https://burohappold.sharepoint.com/:f:/s/BHoM/Egd4_nUinPtCo7NtgkKXJewBqF3dWOa7Ul7Tc2GtPtCfpA?e=WYGtAr

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
