### PR TITLE
Make use of NameOrDescription Comparer when Pushing Properties

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Link.cs
+++ b/Etabs_Adapter/CRUD/Create/Link.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
 #if Debug17 || Release17
 using ETABSv17;
 #elif Debug18 || Release18
@@ -60,7 +61,7 @@ namespace BH.Adapter.ETABS
             {
                 string name = "";
 
-                retA = m_model.LinkObj.AddByPoint(masterNode.CustomData[AdapterIdName].ToString(), slaveNodes[i].CustomData[AdapterIdName].ToString(), ref name, false, constraint.Name);
+                retA = m_model.LinkObj.AddByPoint(masterNode.CustomData[AdapterIdName].ToString(), slaveNodes[i].CustomData[AdapterIdName].ToString(), ref name, false, constraint.DescriptionOrName());
 
                 linkIds.Add(name);
             }
@@ -75,7 +76,7 @@ namespace BH.Adapter.ETABS
         private bool CreateObject(LinkConstraint bhLinkConstraint)
         {
 
-            string name = bhLinkConstraint.Name;
+            string name = bhLinkConstraint.DescriptionOrName();
 
             bool[] dof = new bool[6];
 

--- a/Etabs_Adapter/CRUD/Create/Material.cs
+++ b/Etabs_Adapter/CRUD/Create/Material.cs
@@ -56,14 +56,14 @@ namespace BH.Adapter.ETABS
             string guid = "";
             string notes = "";
             string name = "";
-            if (m_model.PropMaterial.GetMaterial(material.Name, ref matType, ref colour, ref notes, ref guid) != 0)
+            if (m_model.PropMaterial.GetMaterial(material.DescriptionOrName(), ref matType, ref colour, ref notes, ref guid) != 0)
             {
                 m_model.PropMaterial.AddMaterial(ref name, MaterialTypeToCSI(material.IMaterialType()), "", "", "");
-                m_model.PropMaterial.ChangeName(name, material.Name);
+                m_model.PropMaterial.ChangeName(name, material.DescriptionOrName());
                 if (material is IIsotropic)
                 {
                     IIsotropic isotropic = material as IIsotropic;
-                    success &= m_model.PropMaterial.SetMPIsotropic(material.Name, isotropic.YoungsModulus, isotropic.PoissonsRatio, isotropic.ThermalExpansionCoeff) == 0;
+                    success &= m_model.PropMaterial.SetMPIsotropic(material.DescriptionOrName(), isotropic.YoungsModulus, isotropic.PoissonsRatio, isotropic.ThermalExpansionCoeff) == 0;
                 }
                 else if (material is IOrthotropic)
                 {
@@ -72,12 +72,12 @@ namespace BH.Adapter.ETABS
                     double[] v = orthoTropic.PoissonsRatio.ToDoubleArray();
                     double[] a = orthoTropic.ThermalExpansionCoeff.ToDoubleArray();
                     double[] g = orthoTropic.ShearModulus.ToDoubleArray();
-                    success &= m_model.PropMaterial.SetMPOrthotropic(material.Name, ref e, ref v, ref a, ref g) == 0;
+                    success &= m_model.PropMaterial.SetMPOrthotropic(material.DescriptionOrName(), ref e, ref v, ref a, ref g) == 0;
                 }
-                success &= m_model.PropMaterial.SetWeightAndMass(material.Name, 2, material.Density) == 0;
+                success &= m_model.PropMaterial.SetWeightAndMass(material.DescriptionOrName(), 2, material.Density) == 0;
             }
             if (!success)
-                Engine.Reflection.Compute.RecordWarning($"Failed to assign material: {material.Name}, ETABS may have overwritten some properties with default values");
+                Engine.Reflection.Compute.RecordWarning($"Failed to assign material: {material.DescriptionOrName()}, ETABS may have overwritten some properties with default values");
             return success;
         }
 

--- a/Etabs_Adapter/CRUD/Create/Panel.cs
+++ b/Etabs_Adapter/CRUD/Create/Panel.cs
@@ -129,44 +129,35 @@ namespace BH.Adapter.ETABS
             bool success = true;
             int retA = 0;
 
-            string propertyName = "None";
-            if (property2d.Name != "")
-            {
-                property2d.CustomData[AdapterIdName] = propertyName = property2d.Name;
-            }
-            else
-            {
-                BH.Engine.Reflection.Compute.RecordWarning("Surface properties with no name will be converted to the null property 'None'.");
-                property2d.CustomData[AdapterIdName] = "None";
-                return true;
-            }
+            string propertyName = property2d.DescriptionOrName();
+            property2d.CustomData[AdapterIdName] = propertyName;
 
             eShellType shellType = ShellTypeToCSI(property2d);
 
             if (property2d.GetType() == typeof(Waffle))
             {
                 Waffle waffleProperty = (Waffle)property2d;
-                m_model.PropArea.SetSlab(propertyName, eSlabType.Waffle, shellType, property2d.Material.Name, waffleProperty.Thickness);
+                m_model.PropArea.SetSlab(propertyName, eSlabType.Waffle, shellType, property2d.Material.DescriptionOrName(), waffleProperty.Thickness);
                 retA = m_model.PropArea.SetSlabWaffle(propertyName, waffleProperty.TotalDepthX, waffleProperty.Thickness, waffleProperty.StemWidthX, waffleProperty.StemWidthX, waffleProperty.SpacingX, waffleProperty.SpacingY);
             }
             else if (property2d.GetType() == typeof(Ribbed))
             {
                 Ribbed ribbedProperty = (Ribbed)property2d;
-                m_model.PropArea.SetSlab(propertyName, eSlabType.Ribbed, shellType, property2d.Material.Name, ribbedProperty.Thickness);
+                m_model.PropArea.SetSlab(propertyName, eSlabType.Ribbed, shellType, property2d.Material.DescriptionOrName(), ribbedProperty.Thickness);
                 retA = m_model.PropArea.SetSlabRibbed(propertyName, ribbedProperty.TotalDepth, ribbedProperty.Thickness, ribbedProperty.StemWidth, ribbedProperty.StemWidth, ribbedProperty.Spacing, (int)ribbedProperty.Direction);
             }
             else if (property2d.GetType() == typeof(LoadingPanelProperty))
             {
-                retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.Name, 0);
+                retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.DescriptionOrName(), 0);
             }
 
             else if (property2d.GetType() == typeof(ConstantThickness))
             {
                 ConstantThickness constantThickness = (ConstantThickness)property2d;
                 if (constantThickness.PanelType == PanelType.Wall)
-                    retA = m_model.PropArea.SetWall(propertyName, eWallPropType.Specified, shellType, property2d.Material.Name, constantThickness.Thickness);
+                    retA = m_model.PropArea.SetWall(propertyName, eWallPropType.Specified, shellType, property2d.Material.DescriptionOrName(), constantThickness.Thickness);
                 else
-                    retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.Name, constantThickness.Thickness);
+                    retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.DescriptionOrName(), constantThickness.Thickness);
             }
 
 

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -35,6 +35,7 @@ using BH.oM.Geometry;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Adapters.ETABS.Fragments;
 using BH.oM.Adapters.ETABS;
+using BH.Engine.Structure;
 #if Debug17 || Release17
 using ETABSv17;
 #elif Debug18 || Release18
@@ -58,7 +59,7 @@ namespace BH.Adapter.ETABS
         private List<ISectionProperty> ReadSectionProperty(List<string> ids = null)
         {
             List<ISectionProperty> propList = new List<ISectionProperty>();
-            Dictionary<String, IMaterialFragment> bhomMaterials = ReadMaterial().ToDictionary(x => x.Name);
+            Dictionary<String, IMaterialFragment> bhomMaterials = ReadMaterial().ToDictionary(x => x.DescriptionOrName());
 
             int nameCount = 0;
             string[] names = { };
@@ -193,7 +194,7 @@ namespace BH.Adapter.ETABS
                             // Getting a Profile from a name in the propList
                             Func<string, IProfile> getProfile = sectionName =>
                             {
-                                ISectionProperty sec = propList.First(x => x.Name == sectionName);
+                                ISectionProperty sec = propList.First(x => x.DescriptionOrName() == sectionName);
                                 if (sec is IGeometricalSection)
                                     return (sec as IGeometricalSection).SectionProfile;
                                 else
@@ -218,10 +219,10 @@ namespace BH.Adapter.ETABS
                             // Find the material of all elements and create a singel one (or have warning)
                             foreach (string subSectionName in startSec.Concat(endSec))
                             {
-                                ISectionProperty sec = propList.First(x => x.Name == subSectionName);
+                                ISectionProperty sec = propList.First(x => x.DescriptionOrName() == subSectionName);
                                 if (materialName == "")
-                                    materialName = sec.Material.Name;
-                                else if (materialName != sec.Material.Name)
+                                    materialName = sec.Material.DescriptionOrName();
+                                else if (materialName != sec.Material.DescriptionOrName())
                                 {
                                     materialName = "";
                                     Engine.Reflection.Compute.RecordWarning("All sub-sections must have the same material.");

--- a/Etabs_Adapter/Types/Comparer.cs
+++ b/Etabs_Adapter/Types/Comparer.cs
@@ -31,6 +31,7 @@ using BH.oM.Structure.Constraints;
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Base.Objects;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.ETABS
 {
@@ -53,9 +54,9 @@ namespace BH.Adapter.ETABS
             {
                 {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },
                 {typeof(Bar), new BH.Engine.Structure.BarEndNodesDistanceComparer(3) },
-                {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
-                {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
-                {typeof(ISurfaceProperty), new BHoMObjectNameComparer() },
+                {typeof(ISectionProperty), new NameOrDescriptionComparer() },
+                {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
+                {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
                 {typeof(BH.oM.Adapters.ETABS.Elements.Diaphragm), new BHoMObjectNameComparer() },
             };
         }


### PR DESCRIPTION

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #304 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
The macro for Materials and Bars where the properties names have been set to nothing.
Note that the Material test-set complains a lot without this PR as well
https://burohappold.sharepoint.com/:f:/s/BHoM/EkpXsX-vhQNGhFACgImtiXwBstHgGrAfHbNDuyGjyWLtgg?e=fDIMRX


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
