### PR TITLE
FilterRequest by ObjectId

### DIFF
--- a/Etabs_Adapter/CRUD/Read/Bar.cs
+++ b/Etabs_Adapter/CRUD/Read/Bar.cs
@@ -68,6 +68,10 @@ namespace BH.Adapter.ETABS
             {
                 ids = names.ToList();
             }            
+            else
+            {
+                ids = ids.Intersect(names).ToList();
+            }
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Bar.cs
+++ b/Etabs_Adapter/CRUD/Read/Bar.cs
@@ -64,14 +64,7 @@ namespace BH.Adapter.ETABS
             string[] names = { };
             m_model.FrameObj.GetNameList(ref nameCount, ref names);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }            
-            else
-            {
-                ids = ids.Intersect(names).ToList();
-            }
+            ids = FilterIds(ids, names);
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Level.cs
+++ b/Etabs_Adapter/CRUD/Read/Level.cs
@@ -50,13 +50,16 @@ namespace BH.Adapter.ETABS
         private List<Level> ReadLevel(List<string> ids = null)
         {
             List<Level> levellist = new List<Level>();
-            int NumberNames = 0;
-            string[] Names = null;
+            int numberNames = 0;
+            string[] names = null;
+            m_model.Story.GetNameList(ref numberNames, ref names);
 
             if (ids == null)
             {
-                m_model.Story.GetNameList(ref NumberNames, ref Names);
-                ids = Names.ToList();
+                ids = names.ToList();
+            } else
+            {
+                ids = ids.Intersect(names).ToList();
             }
 
             foreach (string id in ids)

--- a/Etabs_Adapter/CRUD/Read/Level.cs
+++ b/Etabs_Adapter/CRUD/Read/Level.cs
@@ -54,13 +54,7 @@ namespace BH.Adapter.ETABS
             string[] names = null;
             m_model.Story.GetNameList(ref numberNames, ref names);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            } else
-            {
-                ids = ids.Intersect(names).ToList();
-            }
+            ids = FilterIds(ids, names);
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Link.cs
+++ b/Etabs_Adapter/CRUD/Read/Link.cs
@@ -57,14 +57,7 @@ namespace BH.Adapter.ETABS
             string[] names = { };
             m_model.LinkObj.GetNameList(ref nameCount, ref names);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(names).ToList();
-            }
+            ids = FilterIds(ids, names);
 
             //read master-multiSlave nodes if these were initially created from (non-etabs)BHoM side
             Dictionary<string, List<string>> idDict = new Dictionary<string, List<string>>();
@@ -156,14 +149,7 @@ namespace BH.Adapter.ETABS
             string[] names = { };
             m_model.PropLink.GetNameList(ref nameCount, ref names);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(names).ToList();
-            }
+            ids = FilterIds(ids, names);
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Link.cs
+++ b/Etabs_Adapter/CRUD/Read/Link.cs
@@ -55,11 +55,15 @@ namespace BH.Adapter.ETABS
 
             int nameCount = 0;
             string[] names = { };
+            m_model.LinkObj.GetNameList(ref nameCount, ref names);
 
             if (ids == null)
             {
-                m_model.LinkObj.GetNameList(ref nameCount, ref names);
                 ids = names.ToList();
+            }
+            else
+            {
+                ids = ids.Intersect(names).ToList();
             }
 
             //read master-multiSlave nodes if these were initially created from (non-etabs)BHoM side
@@ -150,11 +154,15 @@ namespace BH.Adapter.ETABS
             List<LinkConstraint> propList = new List<LinkConstraint>();
             int nameCount = 0;
             string[] names = { };
+            m_model.PropLink.GetNameList(ref nameCount, ref names);
 
             if (ids == null)
             {
-                m_model.PropLink.GetNameList(ref nameCount, ref names);
                 ids = names.ToList();
+            }
+            else
+            {
+                ids = ids.Intersect(names).ToList();
             }
 
             foreach (string id in ids)

--- a/Etabs_Adapter/CRUD/Read/Load.cs
+++ b/Etabs_Adapter/CRUD/Read/Load.cs
@@ -60,6 +60,11 @@ namespace BH.Adapter.ETABS
             
             List<Loadcase> loadcaseList = ReadLoadcase();
 
+            if (ids != null)
+            {
+                Engine.Reflection.Compute.RecordWarning("Id filtering is not implemented for Loads, all Loads will be returned.");
+            }
+
             if (type == typeof(PointLoad))
                 return ReadPointLoad(loadcaseList);
             else if (type == typeof(BarUniformlyDistributedLoad))

--- a/Etabs_Adapter/CRUD/Read/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Read/Loadcase.cs
@@ -61,13 +61,7 @@ namespace BH.Adapter.ETABS
             List<Loadcase> loadcaseList = new List<Loadcase>();
             m_model.LoadPatterns.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = nameArr.ToList();
-            } else
-            {
-                ids = ids.Intersect(nameArr).ToList();
-            }
+            ids = FilterIds(ids, nameArr);
 
             foreach (string id in ids)
             {
@@ -100,15 +94,8 @@ namespace BH.Adapter.ETABS
             string[] nameArr = { };
             m_model.RespCombo.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = nameArr.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(nameArr).ToList();
-            }
-            
+            ids = FilterIds(ids, nameArr);
+
             foreach (string id in ids)
             {
                 LoadCombination combination = new LoadCombination();

--- a/Etabs_Adapter/CRUD/Read/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Read/Loadcase.cs
@@ -59,11 +59,14 @@ namespace BH.Adapter.ETABS
             string[] nameArr = { };
 
             List<Loadcase> loadcaseList = new List<Loadcase>();
+            m_model.LoadPatterns.GetNameList(ref nameCount, ref nameArr);
 
             if (ids == null)
             {
-                m_model.LoadPatterns.GetNameList(ref nameCount, ref nameArr);
                 ids = nameArr.ToList();
+            } else
+            {
+                ids = ids.Intersect(nameArr).ToList();
             }
 
             foreach (string id in ids)
@@ -95,11 +98,15 @@ namespace BH.Adapter.ETABS
 
             int nameCount = 0;
             string[] nameArr = { };
+            m_model.RespCombo.GetNameList(ref nameCount, ref nameArr);
 
             if (ids == null)
             {
-                m_model.RespCombo.GetNameList(ref nameCount, ref nameArr);
                 ids = nameArr.ToList();
+            }
+            else
+            {
+                ids = ids.Intersect(nameArr).ToList();
             }
             
             foreach (string id in ids)

--- a/Etabs_Adapter/CRUD/Read/Material.cs
+++ b/Etabs_Adapter/CRUD/Read/Material.cs
@@ -64,11 +64,14 @@ namespace BH.Adapter.ETABS
             int nameCount = 0;
             string[] names = { };
             List<IMaterialFragment> materialList = new List<IMaterialFragment>();
+            m_model.PropMaterial.GetNameList(ref nameCount, ref names);
 
             if (ids == null)
             {
-                m_model.PropMaterial.GetNameList(ref nameCount, ref names);
                 ids = names.ToList();
+            } else
+            {
+                ids = ids.Intersect(names).ToList();
             }
 
             foreach (string id in ids)

--- a/Etabs_Adapter/CRUD/Read/Material.cs
+++ b/Etabs_Adapter/CRUD/Read/Material.cs
@@ -66,13 +66,7 @@ namespace BH.Adapter.ETABS
             List<IMaterialFragment> materialList = new List<IMaterialFragment>();
             m_model.PropMaterial.GetNameList(ref nameCount, ref names);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            } else
-            {
-                ids = ids.Intersect(names).ToList();
-            }
+            ids = FilterIds(ids, names);
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Mesh.cs
+++ b/Etabs_Adapter/CRUD/Read/Mesh.cs
@@ -66,14 +66,7 @@ namespace BH.Adapter.ETABS
             string[] nameArr = { };
             m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = nameArr.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(nameArr).ToList();
-            }
+            ids = FilterIds(ids, nameArr);
 
             List<FEMesh> meshes = new List<FEMesh>();
             Dictionary<string, Node> nodes = new Dictionary<string, Node>();

--- a/Etabs_Adapter/CRUD/Read/Mesh.cs
+++ b/Etabs_Adapter/CRUD/Read/Mesh.cs
@@ -64,11 +64,15 @@ namespace BH.Adapter.ETABS
             List<Panel> panelList = new List<Panel>();
             int nameCount = 0;
             string[] nameArr = { };
+            m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
 
             if (ids == null)
             {
-                m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
                 ids = nameArr.ToList();
+            }
+            else
+            {
+                ids = ids.Intersect(nameArr).ToList();
             }
 
             List<FEMesh> meshes = new List<FEMesh>();

--- a/Etabs_Adapter/CRUD/Read/Node.cs
+++ b/Etabs_Adapter/CRUD/Read/Node.cs
@@ -66,13 +66,17 @@ namespace BH.Adapter.ETABS
 
             int nameCount = 0;
             string[] nameArr = { };
+            m_model.PointObj.GetNameList(ref nameCount, ref nameArr);
 
             if (ids == null)
             {
-                m_model.PointObj.GetNameList(ref nameCount, ref nameArr);
                 ids = nameArr.ToList();
             }
-
+            else
+            {
+                ids = ids.Intersect(nameArr).ToList();
+            }
+            
             foreach (string id in ids)
             {
 

--- a/Etabs_Adapter/CRUD/Read/Node.cs
+++ b/Etabs_Adapter/CRUD/Read/Node.cs
@@ -68,15 +68,8 @@ namespace BH.Adapter.ETABS
             string[] nameArr = { };
             m_model.PointObj.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = nameArr.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(nameArr).ToList();
-            }
-            
+            ids = FilterIds(ids, nameArr);
+
             foreach (string id in ids)
             {
 

--- a/Etabs_Adapter/CRUD/Read/Panel.cs
+++ b/Etabs_Adapter/CRUD/Read/Panel.cs
@@ -72,14 +72,7 @@ namespace BH.Adapter.ETABS
             string[] nameArr = { };
             m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = nameArr.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(nameArr).ToList();
-            }
+            ids = FilterIds(ids, nameArr);
 
             //get openings, if any
             m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
@@ -162,14 +155,7 @@ namespace BH.Adapter.ETABS
             string[] nameArr = { };
             m_model.PropArea.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = nameArr.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(nameArr).ToList();
-            }
+            ids = FilterIds(ids, nameArr);
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Panel.cs
+++ b/Etabs_Adapter/CRUD/Read/Panel.cs
@@ -70,11 +70,15 @@ namespace BH.Adapter.ETABS
             Dictionary<string, ISurfaceProperty> bhomProperties = ReadSurfaceProperty().ToDictionary(x => x.CustomData[AdapterIdName].ToString());
             int nameCount = 0;
             string[] nameArr = { };
+            m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
 
             if (ids == null)
             {
-                m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
                 ids = nameArr.ToList();
+            }
+            else
+            {
+                ids = ids.Intersect(nameArr).ToList();
             }
 
             //get openings, if any
@@ -156,11 +160,15 @@ namespace BH.Adapter.ETABS
 
             int nameCount = 0;
             string[] nameArr = { };
+            m_model.PropArea.GetNameList(ref nameCount, ref nameArr);
 
             if (ids == null)
             {
-                m_model.PropArea.GetNameList(ref nameCount, ref nameArr);
                 ids = nameArr.ToList();
+            }
+            else
+            {
+                ids = ids.Intersect(nameArr).ToList();
             }
 
             foreach (string id in ids)

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -65,14 +65,7 @@ namespace BH.Adapter.ETABS
             string[] names = { };
             m_model.PropFrame.GetNameList(ref nameCount, ref names);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }
-            else
-            {
-                ids = ids.Intersect(names).ToList();
-            }
+            ids = FilterIds(ids, names);
 
             eFramePropType propertyType = eFramePropType.General;
 

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -69,6 +69,10 @@ namespace BH.Adapter.ETABS
             {
                 ids = names.ToList();
             }
+            else
+            {
+                ids = ids.Intersect(names).ToList();
+            }
 
             eFramePropType propertyType = eFramePropType.General;
 

--- a/Etabs_Adapter/CRUD/Read/_Read.cs
+++ b/Etabs_Adapter/CRUD/Read/_Read.cs
@@ -48,6 +48,7 @@ using BH.oM.Geometry.SettingOut;
 using BH.oM.Architecture.Elements;
 using BH.oM.Adapters.ETABS.Elements;
 using BH.oM.Adapter;
+using System.ComponentModel;
 
 namespace BH.Adapter.ETABS
 {
@@ -102,6 +103,25 @@ namespace BH.Adapter.ETABS
         }
 
         /***************************************************/
+
+        [Description("Ensures that all elements in the first list are present in the second list, warning if not, and returns the second list if the first list is empty.")]
+        private static List<string> FilterIds(IEnumerable<string> ids, IEnumerable<string> etabsIds)
+        {
+            if (ids == null || ids.Count() == 0)
+            {
+                return etabsIds.ToList();
+            }
+            else
+            {
+                List<string> result = ids.Intersect(etabsIds).ToList();
+                if (result.Count() != ids.Count())
+                    Engine.Reflection.Compute.RecordWarning("Some requested ETABS ids were not present in the model.");
+                return result;
+            }
+        }
+
+        /***************************************************/
+
     }
 }
 

--- a/Etabs_Adapter/CRUD/Read/_Read.cs
+++ b/Etabs_Adapter/CRUD/Read/_Read.cs
@@ -66,37 +66,37 @@ namespace BH.Adapter.ETABS
         protected override IEnumerable<IBHoMObject> IRead(Type type, IList ids, ActionConfig actionConfig = null)
         {
             List<string> listIds = null;
-            if (ids != null)
+            if (ids != null && ids.Count != 0)
                 listIds = ids.Cast<string>().ToList();
 
             if (type == typeof(Node))
-                return ReadNode(ids as dynamic);
+                return ReadNode(listIds);
             else if (type == typeof(Bar))
-                return ReadBar(ids as dynamic);
+                return ReadBar(listIds);
             else if (type == typeof(ISectionProperty) || type.GetInterfaces().Contains(typeof(ISectionProperty)))
-                return ReadSectionProperty(ids as dynamic);
+                return ReadSectionProperty(listIds);
             else if (type == typeof(IMaterialFragment))
-                return ReadMaterial(ids as dynamic);
+                return ReadMaterial(listIds);
             else if (type == typeof(Panel))
-                return ReadPanel(ids as dynamic);
+                return ReadPanel(listIds);
             else if (type == typeof(ISurfaceProperty))
-                return ReadSurfaceProperty(ids as dynamic);
+                return ReadSurfaceProperty(listIds);
             else if (type == typeof(LoadCombination))
-                return ReadLoadCombination(ids as dynamic);
+                return ReadLoadCombination(listIds);
             else if (type == typeof(Loadcase))
-                return ReadLoadcase(ids as dynamic);
+                return ReadLoadcase(listIds);
             else if (type == typeof(ILoad) || type.GetInterfaces().Contains(typeof(ILoad)))
-                return ReadLoad(type, ids as dynamic);
+                return ReadLoad(type, listIds);
             else if (type == typeof(RigidLink))
-                return ReadRigidLink(ids as dynamic);
+                return ReadRigidLink(listIds);
             else if (type == typeof(LinkConstraint))
-                return ReadLinkConstraints(ids as dynamic);
+                return ReadLinkConstraints(listIds);
             else if (type == typeof(oM.Geometry.SettingOut.Level) || type == typeof(oM.Architecture.Elements.Level))
-                return ReadLevel(ids as dynamic);
+                return ReadLevel(listIds);
             else if (type == typeof(oM.Geometry.SettingOut.Grid))
                 return ReadGrid(listIds);
             else if (type == typeof(FEMesh))
-                return ReadMesh(ids as dynamic);
+                return ReadMesh(listIds);
 
             return new List<IBHoMObject>();//<--- returning null will throw error in replace method of BHOM_Adapter line 34: can't do typeof(null) - returning null does seem the most sensible to return though
         }


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #279 
request by id now works by fixing the cast from `IList` to `List<string>` and a failsafe for faulty requests has been implemented by taking the intersection of all ids in ETABS by the provided ones

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EsHk-mo4drxEiLsc_8nhGw0BXh_gikpTfOifxNHiQKaAtw?e=Cp37ai

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
