### PR TITLE
Update of Panel

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Diaphragm.cs
+++ b/Etabs_Adapter/CRUD/Create/Diaphragm.cs
@@ -22,16 +22,27 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
+using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Loads;
+using BH.oM.Structure.Offsets;
 using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
-using BH.oM.Adapter;
+using BH.oM.Adapters.ETABS;
+
+#if Debug17 || Release17
+using ETABSv17;
+#elif Debug18 || Release18
+using ETABSv1;
+#else
+using ETABS2016;
+#endif
 
 namespace BH.Adapter.ETABS
 {
@@ -44,23 +55,17 @@ namespace BH.Adapter.ETABS
 #endif
     {
         /***************************************************/
-        /**** Adapter override methods                  ****/
+        /***    Create Methods                           ***/
         /***************************************************/
 
-        protected override bool IUpdate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)
+        private bool CreateObject(Diaphragm diaphragm)
         {
-            if (typeof(T) == typeof(Node))
-            {
-                return UpdateObjects(objects as IEnumerable<Node>);
-            }
-            if (typeof(T) == typeof(Panel))
-            {
-                return UpdateObjects(objects as IEnumerable<Panel>);
-            }
-            else
-                return base.IUpdate<T>(objects, actionConfig);
-        }
+            bool sucess = true;
+            sucess &= m_model.Diaphragm.SetDiaphragm(diaphragm.Name, diaphragm.Rigidity == oM.Adapters.ETABS.DiaphragmType.SemiRigidDiaphragm) == 0;
 
+            return sucess;
+        }
+        
         /***************************************************/
     }
 }

--- a/Etabs_Adapter/CRUD/Create/Panel.cs
+++ b/Etabs_Adapter/CRUD/Create/Panel.cs
@@ -114,8 +114,20 @@ namespace BH.Adapter.ETABS
             }
 
 
+            Pier pier = bhPanel.Pier();
+            Spandrel spandrel = bhPanel.Spandrel();
             Diaphragm diaphragm = bhPanel.Diaphragm();
 
+            if (pier != null)
+            {
+                int ret = m_model.PierLabel.SetPier(pier.Name);
+                ret = m_model.AreaObj.SetPier(name, pier.Name);
+            }
+            if (spandrel != null)
+            {
+                int ret = m_model.SpandrelLabel.SetSpandrel(spandrel.Name, false);
+                ret = m_model.AreaObj.SetSpandrel(name, spandrel.Name);
+            }
             if (diaphragm != null)
             {
                 m_model.AreaObj.SetDiaphragm(name, diaphragm.Name);

--- a/Etabs_Adapter/CRUD/Create/Panel.cs
+++ b/Etabs_Adapter/CRUD/Create/Panel.cs
@@ -108,6 +108,8 @@ namespace BH.Adapter.ETABS
                     string openingName = name + "_Opening_" + i;
                     m_model.AreaObj.AddByCoord(segmentCount, ref x, ref y, ref z, ref openingName, "");//<-- setting panel property to empty string, verify that this is correct
                     m_model.AreaObj.SetOpening(openingName, true);
+
+                    bhPanel.Openings[i].CustomData[AdapterIdName] = openingName;
                 }
             }
 
@@ -121,92 +123,9 @@ namespace BH.Adapter.ETABS
 
             return success;
         }
-
+        
         /***************************************************/
-
-        private bool CreateObject(ISurfaceProperty property2d)
-        {
-            bool success = true;
-            int retA = 0;
-
-            string propertyName = property2d.DescriptionOrName();
-            property2d.CustomData[AdapterIdName] = propertyName;
-
-            eShellType shellType = ShellTypeToCSI(property2d);
-
-            if (property2d.GetType() == typeof(Waffle))
-            {
-                Waffle waffleProperty = (Waffle)property2d;
-                m_model.PropArea.SetSlab(propertyName, eSlabType.Waffle, shellType, property2d.Material.DescriptionOrName(), waffleProperty.Thickness);
-                retA = m_model.PropArea.SetSlabWaffle(propertyName, waffleProperty.TotalDepthX, waffleProperty.Thickness, waffleProperty.StemWidthX, waffleProperty.StemWidthX, waffleProperty.SpacingX, waffleProperty.SpacingY);
-            }
-            else if (property2d.GetType() == typeof(Ribbed))
-            {
-                Ribbed ribbedProperty = (Ribbed)property2d;
-                m_model.PropArea.SetSlab(propertyName, eSlabType.Ribbed, shellType, property2d.Material.DescriptionOrName(), ribbedProperty.Thickness);
-                retA = m_model.PropArea.SetSlabRibbed(propertyName, ribbedProperty.TotalDepth, ribbedProperty.Thickness, ribbedProperty.StemWidth, ribbedProperty.StemWidth, ribbedProperty.Spacing, (int)ribbedProperty.Direction);
-            }
-            else if (property2d.GetType() == typeof(LoadingPanelProperty))
-            {
-                retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.DescriptionOrName(), 0);
-            }
-
-            else if (property2d.GetType() == typeof(ConstantThickness))
-            {
-                ConstantThickness constantThickness = (ConstantThickness)property2d;
-                if (constantThickness.PanelType == PanelType.Wall)
-                    retA = m_model.PropArea.SetWall(propertyName, eWallPropType.Specified, shellType, property2d.Material.DescriptionOrName(), constantThickness.Thickness);
-                else
-                    retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.DescriptionOrName(), constantThickness.Thickness);
-            }
-
-
-            if (property2d.HasModifiers())
-            {
-                double[] modifier = property2d.Modifiers();//(double[])property2d.CustomData["Modifiers"];
-                m_model.PropArea.SetModifiers(propertyName, ref modifier);
-            }
-
-            if (retA != 0)
-                success = false;
-
-            return success;
-        }
-
-        /***************************************************/
-
-        private bool CreateObject(Diaphragm diaphragm)
-        {
-            bool sucess = true;
-            sucess &= m_model.Diaphragm.SetDiaphragm(diaphragm.Name, diaphragm.Rigidity == oM.Adapters.ETABS.DiaphragmType.SemiRigidDiaphragm) == 0;
-
-            return sucess;
-        }
-
-        /***************************************************/
-        /***    Helper Methods                           ***/
-        /***************************************************/
-
-        private eShellType ShellTypeToCSI(ISurfaceProperty panel)
-        {
-            object obj;
-
-            if (panel.CustomData.TryGetValue("ShellType", out obj) && obj is ShellType)
-            {
-                switch ((ShellType)obj)
-                {
-                    case ShellType.ShellThin:
-                        return eShellType.ShellThin;
-                    case ShellType.ShellThick:
-                        return eShellType.ShellThick;
-                    case ShellType.Membrane:
-                        return eShellType.Membrane;
-                }
-            }
-            return eShellType.ShellThin;
-        }
-
-        /***************************************************/
+        
     }
 }
 

--- a/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -1,0 +1,137 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Geometry.SettingOut;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Structure.Constraints;
+using BH.oM.Structure.SurfaceProperties;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Offsets;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+using BH.oM.Structure.MaterialFragments;
+using BH.Engine.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.oM.Adapters.ETABS;
+
+#if Debug17 || Release17
+using ETABSv17;
+#elif Debug18 || Release18
+using ETABSv1;
+#else
+using ETABS2016;
+#endif
+
+namespace BH.Adapter.ETABS
+{
+#if Debug17 || Release17
+    public partial class ETABS17Adapter : BHoMAdapter
+#elif Debug18 || Release18
+   public partial class ETABS18Adapter : BHoMAdapter
+#else
+    public partial class ETABS2016Adapter : BHoMAdapter
+#endif
+    {
+        /***************************************************/
+        /***    Create Methods                           ***/
+        /***************************************************/
+
+        private bool CreateObject(ISurfaceProperty property2d)
+        {
+            bool success = true;
+            int retA = 0;
+
+            string propertyName = property2d.DescriptionOrName();
+            property2d.CustomData[AdapterIdName] = propertyName;
+
+            eShellType shellType = ShellTypeToCSI(property2d);
+
+            if (property2d.GetType() == typeof(Waffle))
+            {
+                Waffle waffleProperty = (Waffle)property2d;
+                m_model.PropArea.SetSlab(propertyName, eSlabType.Waffle, shellType, property2d.Material.DescriptionOrName(), waffleProperty.Thickness);
+                retA = m_model.PropArea.SetSlabWaffle(propertyName, waffleProperty.TotalDepthX, waffleProperty.Thickness, waffleProperty.StemWidthX, waffleProperty.StemWidthX, waffleProperty.SpacingX, waffleProperty.SpacingY);
+            }
+            else if (property2d.GetType() == typeof(Ribbed))
+            {
+                Ribbed ribbedProperty = (Ribbed)property2d;
+                m_model.PropArea.SetSlab(propertyName, eSlabType.Ribbed, shellType, property2d.Material.DescriptionOrName(), ribbedProperty.Thickness);
+                retA = m_model.PropArea.SetSlabRibbed(propertyName, ribbedProperty.TotalDepth, ribbedProperty.Thickness, ribbedProperty.StemWidth, ribbedProperty.StemWidth, ribbedProperty.Spacing, (int)ribbedProperty.Direction);
+            }
+            else if (property2d.GetType() == typeof(LoadingPanelProperty))
+            {
+                retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.DescriptionOrName(), 0);
+            }
+
+            else if (property2d.GetType() == typeof(ConstantThickness))
+            {
+                ConstantThickness constantThickness = (ConstantThickness)property2d;
+                if (constantThickness.PanelType == PanelType.Wall)
+                    retA = m_model.PropArea.SetWall(propertyName, eWallPropType.Specified, shellType, property2d.Material.DescriptionOrName(), constantThickness.Thickness);
+                else
+                    retA = m_model.PropArea.SetSlab(propertyName, eSlabType.Slab, shellType, property2d.Material.DescriptionOrName(), constantThickness.Thickness);
+            }
+
+
+            if (property2d.HasModifiers())
+            {
+                double[] modifier = property2d.Modifiers();//(double[])property2d.CustomData["Modifiers"];
+                m_model.PropArea.SetModifiers(propertyName, ref modifier);
+            }
+
+            if (retA != 0)
+                success = false;
+
+            return success;
+        }
+        
+        
+        /***************************************************/
+        /***    Helper Methods                           ***/
+        /***************************************************/
+
+        private eShellType ShellTypeToCSI(ISurfaceProperty panel)
+        {
+            object obj;
+
+            if (panel.CustomData.TryGetValue("ShellType", out obj) && obj is ShellType)
+            {
+                switch ((ShellType)obj)
+                {
+                    case ShellType.ShellThin:
+                        return eShellType.ShellThin;
+                    case ShellType.ShellThick:
+                        return eShellType.ShellThick;
+                    case ShellType.Membrane:
+                        return eShellType.Membrane;
+                }
+            }
+            return eShellType.ShellThin;
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Etabs_Adapter/CRUD/Update/Node.cs
+++ b/Etabs_Adapter/CRUD/Update/Node.cs
@@ -44,21 +44,40 @@ namespace BH.Adapter.ETABS
 #endif
     {
         /***************************************************/
-        /**** Adapter override methods                  ****/
+        /**** Update Node                               ****/
         /***************************************************/
-
-        protected override bool IUpdate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)
+        
+        private bool UpdateObjects(IEnumerable<Node> nodes)
         {
-            if (typeof(T) == typeof(Node))
+            bool success = true;
+            foreach (Node bhNode in nodes)
             {
-                return UpdateObjects(objects as IEnumerable<Node>);
+                if (bhNode.Support != null)
+                {
+                    string name = bhNode.CustomData[AdapterIdName].ToString();
+
+                    bool[] restraint = new bool[6];
+                    restraint[0] = bhNode.Support.TranslationX == DOFType.Fixed;
+                    restraint[1] = bhNode.Support.TranslationY == DOFType.Fixed;
+                    restraint[2] = bhNode.Support.TranslationZ == DOFType.Fixed;
+                    restraint[3] = bhNode.Support.RotationX == DOFType.Fixed;
+                    restraint[4] = bhNode.Support.RotationY == DOFType.Fixed;
+                    restraint[5] = bhNode.Support.RotationZ == DOFType.Fixed;
+
+                    double[] spring = new double[6];
+                    spring[0] = bhNode.Support.TranslationalStiffnessX;
+                    spring[1] = bhNode.Support.TranslationalStiffnessY;
+                    spring[2] = bhNode.Support.TranslationalStiffnessZ;
+                    spring[3] = bhNode.Support.RotationalStiffnessX;
+                    spring[4] = bhNode.Support.RotationalStiffnessY;
+                    spring[5] = bhNode.Support.RotationalStiffnessZ;
+
+                    success &= m_model.PointObj.SetRestraint(name, ref restraint) == 0;
+                    success &= m_model.PointObj.SetSpring(name, ref spring) == 0;
+                }
             }
-            if (typeof(T) == typeof(Panel))
-            {
-                return UpdateObjects(objects as IEnumerable<Panel>);
-            }
-            else
-                return base.IUpdate<T>(objects, actionConfig);
+
+            return success;
         }
 
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/Panel.cs
+++ b/Etabs_Adapter/CRUD/Update/Panel.cs
@@ -58,7 +58,7 @@ namespace BH.Adapter.ETABS
                 string name = bhPanel.CustomData[AdapterIdName].ToString();
                 string propertyName = bhPanel.Property.CustomData[AdapterIdName].ToString();
 
-                Engine.Reflection.Compute.RecordWarning("Update Panel does not affect the geometry of the panel. Openings are geometrical.");
+                Engine.Reflection.Compute.RecordWarning("The Etabs API does not allow for updating of the geometry of panels. This includes the external edges as well as the openings. To update the panel geometry, delete the existing panel you want to update and create a new one..");
 
                 m_model.AreaObj.SetProperty(name, propertyName);
 
@@ -89,4 +89,3 @@ namespace BH.Adapter.ETABS
 
     }
 }
-

--- a/Etabs_Adapter/CRUD/Update/Panel.cs
+++ b/Etabs_Adapter/CRUD/Update/Panel.cs
@@ -58,7 +58,7 @@ namespace BH.Adapter.ETABS
                 string name = bhPanel.CustomData[AdapterIdName].ToString();
                 string propertyName = bhPanel.Property.CustomData[AdapterIdName].ToString();
 
-                Engine.Reflection.Compute.RecordWarning("The Etabs API does not allow for updating of the geometry of panels. This includes the external edges as well as the openings. To update the panel geometry, delete the existing panel you want to update and create a new one..");
+                Engine.Reflection.Compute.RecordWarning("The Etabs API does not allow for updating of the geometry of panels. This includes the external edges as well as the openings. To update the panel geometry, delete the existing panel you want to update and create a new one.");
 
                 m_model.AreaObj.SetProperty(name, propertyName);
 

--- a/Etabs_Adapter/CRUD/Update/_Update.cs
+++ b/Etabs_Adapter/CRUD/Update/_Update.cs
@@ -49,6 +49,15 @@ namespace BH.Adapter.ETABS
 
         protected override bool IUpdate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)
         {
+            if (typeof(T) == typeof(Panel))
+            {
+                List<Panel> panels = objects.Cast<Panel>().ToList();
+
+                List<Diaphragm> diaphragms = panels.Select(x => x.Diaphragm()).Where(x => x != null).ToList();
+
+                this.FullCRUD(diaphragms, PushType.FullPush);
+            }
+
             if (typeof(T) == typeof(Node))
             {
                 return UpdateObjects(objects as IEnumerable<Node>);

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -336,6 +336,8 @@
   <ItemGroup>
     <Compile Include="AdapterActions\Exectute.cs" />
     <Compile Include="CRUD\Create\Loadcase.cs" />
+    <Compile Include="CRUD\Create\Diaphragm.cs" />
+    <Compile Include="CRUD\Create\SurfaceProperty.cs" />
     <Compile Include="CRUD\Create\SectionProperty.cs" />
     <Compile Include="CRUD\Create\Panel.cs" />
     <Compile Include="CRUD\Create\Material.cs" />
@@ -354,6 +356,8 @@
     <Compile Include="CRUD\Read\Results\GlobalResults.cs" />
     <Compile Include="CRUD\Read\Results\NodeResults.cs" />
     <Compile Include="CRUD\Read\Results\MeshResults.cs" />
+    <Compile Include="CRUD\Update\Node.cs" />
+    <Compile Include="CRUD\Update\Panel.cs" />
     <Compile Include="Types\NextIndex.cs" />
     <Compile Include="CRUD\Read\Link.cs" />
     <Compile Include="CRUD\Read\Material.cs" />


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #145 
Closes #142 

Can't move an Panel without moving it's nodes, which would move connected Panels as well. The other option would be to re-create the Panel, but that would remove load information and every other kind of information added to the panel in ETABS. So think that functionality is better left in Create.

The last resort would be to get as much data on the object within the method and reassign after recreating the Panel, but don't know if the API allows one to get and set all kinds of data, and would have to be manually updated if the API changes to retain it's Update functionality 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
I don't know what Pier & Spandrel is or where I can find it in ETABS
https://burohappold.sharepoint.com/:u:/s/BHoM/EYVMwIVqAnZIrGME4-G1KcQBczx_4ytUEgcxgEIEnMDvqQ?e=Sfui9W

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- All properties apart from the geometry
- Add Pier & Spandrel to the Create Panel method

 ### Additional comments
<!-- As required -->
Also did some housekeeping for the files and added Pier & Spandrel to the create method.

And doing the update makes the Push quite unhappy since no other things Update has been implemented.

