### PR TITLE
Align with changes in Structure_oM making results immutable

### DIFF
--- a/ETABS_oM/Elements/PierForce.cs
+++ b/ETABS_oM/Elements/PierForce.cs
@@ -38,7 +38,17 @@ namespace BH.oM.Adapters.ETABS.Elements
         /***************************************************/
 
         //Just using this for the name
-        public virtual string Location { get; set; } = "";
+        public virtual string Location { get; } = "";
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public PierForce(IComparable objectId, IComparable resultCase, string location, int modeNumber, double timeStep, double position, int divisions, double fx, double fy, double fz, double mx, double my, double mz)
+            : base(objectId, resultCase, modeNumber, timeStep, position, divisions, fx, fy, fz, mx, my, mz)
+        {
+            Location = location;
+        }
 
         /***************************************************/
     }

--- a/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
@@ -124,22 +124,11 @@ namespace BH.Adapter.ETABS
                 {
                     for (int j = 0; j < resultCount; j++)
                     {
+                        int mode;
+                        double timeStep;
+                        GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
 
-                        BarForce bf = new BarForce()
-                        {
-                            ResultCase = loadcaseNames[j],
-                            ObjectId = barIds[i],
-                            MX = t[j],
-                            MY = -m3[j],
-                            MZ = m2[j],
-                            FX = p[j],
-                            FY = v3[j],
-                            FZ = v2[j],
-                            Divisions = divs,
-                            Position = objStation[j] /length,
-                            TimeStep = stepNum[j]
-                        };
-
+                        BarForce bf = new BarForce(barIds[i], loadcaseNames[j], mode, timeStep, objStation[j] / length, divs, p[j], v3[j], v2[j], t[j], -m3[j], m2[j]);
                         barForces.Add(bf);
                     }
                 }
@@ -157,11 +146,11 @@ namespace BH.Adapter.ETABS
             Engine.Reflection.Compute.RecordWarning("Displacements will only be extracted at ETABS calculation nodes. 'Divisions' parameter will not be considered in result extraction");
 
             int resultCount = 0;
-            string[] Obj = null;
-            string[] Elm = null;
-            string[] LoadCase = null;
-            string[] StepType = null;
-            double[] StepNum = null;
+            string[] obj = null;
+            string[] elm = null;
+            string[] loadCase = null;
+            string[] stepType = null;
+            double[] stepNum = null;
 
             double[] ux = null;
             double[] uy = null;
@@ -196,26 +185,17 @@ namespace BH.Adapter.ETABS
 
                 foreach (var nodePos in nodeWithPos)
                 {
-                    int ret = m_model.Results.JointDispl(nodePos.Key, eItemTypeElm.Element, ref resultCount, ref Obj, ref Elm, ref LoadCase, ref StepType, ref StepNum, ref ux, ref uy, ref uz, ref rx, ref ry, ref rz);
+                    int ret = m_model.Results.JointDispl(nodePos.Key, eItemTypeElm.Element, ref resultCount, ref obj, ref elm, ref loadCase, ref stepType, ref stepNum, ref ux, ref uy, ref uz, ref rx, ref ry, ref rz);
                     
                     if (ret == 0)
                     {
                         for (int j = 0; j < resultCount; j++)
                         {
-                            BarDisplacement disp = new BarDisplacement
-                            {
-                                UX = ux[j],
-                                UY = uy[j],
-                                UZ = uz[j],
-                                RX = rx[j],
-                                RY = ry[j],
-                                RZ = rz[j],
-                                ObjectId = barIds[i],
-                                Divisions = divs + 1,
-                                Position = nodePos.Value,
-                                ResultCase = LoadCase[j],
-                                TimeStep = StepNum[j]
-                            };
+                            int mode;
+                            double timeStep;
+                            GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
+
+                            BarDisplacement disp = new BarDisplacement(barIds[i], loadCase[j], mode, timeStep, nodePos.Value, divs + 1, ux[j], uy[j], uz[j], rx[j], ry[j], rz[j]);
                             displacements.Add(disp);
                         }
                     }

--- a/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -92,34 +92,25 @@ namespace BH.Adapter.ETABS
             string[] elm = null;
             string[] stepType = null;
             double[] stepNum = null;
-            double[] fx = null;
-            double[] fy = null;
-            double[] fz = null;
-            double[] mx = null;
-            double[] my = null;
-            double[] mz = null;
+            double[] ux = null;
+            double[] uy = null;
+            double[] uz = null;
+            double[] rx = null;
+            double[] ry = null;
+            double[] rz = null;
 
             for (int i = 0; i < nodeIds.Count; i++)
             {
                 int ret = m_model.Results.JointDispl(nodeIds[i].ToString(), eItemTypeElm.ObjectElm, ref resultCount, ref objects, ref elm,
-                ref loadcaseNames, ref stepType, ref stepNum, ref fx, ref fy, ref fz, ref mx, ref my, ref mz);
+                ref loadcaseNames, ref stepType, ref stepNum, ref ux, ref uy, ref uz, ref rx, ref ry, ref rz);
                 if (ret == 0)
                 {
                     for (int j = 0; j < resultCount; j++)
                     {
-
-                        NodeDisplacement nd = new NodeDisplacement()
-                        {
-                            ResultCase = loadcaseNames[j],
-                            ObjectId = nodeIds[i],
-                            RX = mx[j],
-                            RY = my[j],
-                            RZ = mz[j],
-                            UX = fx[j],
-                            UY = fy[j],
-                            UZ = fz[j],
-                            TimeStep = stepNum[j]
-                        };
+                        int mode;
+                        double timeStep;
+                        GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
+                        NodeDisplacement nd = new NodeDisplacement(nodeIds[i], loadcaseNames[j], mode, timeStep, oM.Geometry.Basis.XY, ux[j], uy[j], uz[j], rx[j], ry[j], rz[j]);
                         nodeDisplacements.Add(nd);
                     }
                 }
@@ -158,19 +149,10 @@ namespace BH.Adapter.ETABS
                 {
                     for (int j = 0; j < resultCount; j++)
                     {
-                        //string step = stepType[j] != null ? stepType[j] == "Max" ? " Max" : stepType[j] == "Min" ? " Min" : "1" : "0";
-                        NodeReaction nr = new NodeReaction()
-                        {
-                            ResultCase = loadcaseNames[j],
-                            ObjectId = nodeIds[i],
-                            MX = mx[j],
-                            MY = my[j],
-                            MZ = mz[j],
-                            FX = fx[j],
-                            FY = fy[j],
-                            FZ = fz[j],
-                            TimeStep = stepNum[j]
-                        };
+                        int mode;
+                        double timeStep;
+                        GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
+                        NodeReaction nr = new NodeReaction(nodeIds[i], loadcaseNames[j], mode, timeStep, oM.Geometry.Basis.XY, fx[j], fy[j], fz[j], mx[j], my[j], mz[j]);
                         nodeReactions.Add(nr);
                     }
                 }

--- a/Etabs_Adapter/CRUD/Read/Results/Result.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/Result.cs
@@ -104,22 +104,9 @@ namespace BH.Adapter.ETABS
                     {
                         position = 1;
                     }
-                    PierForce bf = new PierForce()
-                    {
-                        ResultCase = loadcaseNames[j],
-                        ObjectId = pierName[j],
-                        MX = t[j],
-                        MY = m2[j],
-                        MZ = m3[j],
-                        FX = p[j],
-                        FY = v2[j],
-                        FZ = v3[j],
-                        //Divisions = divisions,
-                        Position = position,
-                        // TimeStep = stepNum[j]
-                    };
-                    bf.Location = storyName[j];
-                    pierForces.Add(bf);
+
+                    PierForce pf = new PierForce(pierName[j], loadcaseNames[j], storyName[j], 0, 0, position, 2, p[j], v2[j], v3[j], t[j], m2[j], m3[j]);
+                    pierForces.Add(pf);
                 }
 
             }
@@ -207,6 +194,22 @@ namespace BH.Adapter.ETABS
                 }
             }
             return true;
+        }
+
+        /***************************************************/
+
+        private void GetStepAndMode(string stepType, double stepNum, out double timeStep, out int mode)
+        {
+            if (stepType == "Mode")
+            {
+                mode = (int)stepNum;
+                timeStep = 0;
+            }
+            else
+            {
+                timeStep = stepNum;
+                mode = 0;
+            }
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/912

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


 <!-- Add short description of what has been fixed -->

Align with changes in Structure_oM making results immutable
Adding first filter trying to identify if "StepNum" is mode or not.

Also updated the method used for modal dynamics to one that more closely reassembles the result class returned.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EgTmkOTgxdxOr2rodGPhLVIBo7P8mT7QjcjM8TOGdKVDuQ?e=PBfCCt

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
