### PR TITLE
Fix push of Levels at or below zero

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Level.cs
+++ b/Etabs_Adapter/CRUD/Create/Level.cs
@@ -74,13 +74,11 @@ namespace BH.Adapter.ETABS
 
             double[] elevations;
 
-
             elevations = new double[count];
             for (int i = 0; i < count; i++)
             {
                 elevations[i] = levelList[i].Elevation;
             }
-
 
             //Reduce the count for the heights etc, as the baselevel is not included in the API call
             count--;

--- a/Etabs_Adapter/CRUD/Create/Level.cs
+++ b/Etabs_Adapter/CRUD/Create/Level.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.ETABS
                 elevations[i + 1] = levelList[i].Elevation;
             }
 
-            if (elevations.Any(x => x <= 0))
+            if (levelList.Any(x => x.Elevation <= 0))
             {
                 Engine.Reflection.Compute.RecordError("Levels can not be pushed as equal to or below zero in ETABS16.");
             }

--- a/Etabs_Adapter/CRUD/Create/Level.cs
+++ b/Etabs_Adapter/CRUD/Create/Level.cs
@@ -58,18 +58,37 @@ namespace BH.Adapter.ETABS
             double[] heights = new double[count];   //Heights empty, set by elevations
 
 #if Debug16 || Release16
-            double[] elevations = new double[count + 1];
 
-            for (int i = 0; i < count; i++)
-            {
-                elevations[i + 1] = levelList[i].Elevation;
-            }
+            double[] elevations;
 
-            if (levelList.Any(x => x.Elevation <= 0))
+            //Check if any level is lower than or equal 0, if so base level set to lowes level
+            if (levelList.First().Elevation <= 0)
             {
-                Engine.Reflection.Compute.RecordError("Levels can not be pushed as equal to or below zero in ETABS16.");
+                elevations = new double[count];
+                for (int i = 0; i < count; i++)
+                {
+                    elevations[i] = levelList[i].Elevation;
+                }
+
+                //remove the first name, as first level will be the base level
+                names = names.Skip(1).ToArray();
+
+                Engine.Reflection.Compute.RecordNote("First level will be the base level and will not be given the provided name");
+
+                //Reduce the count for the heights etc, as the baselevel is not included in the API call
+                count--;
             }
-            return true;
+            else
+            {
+                //When provided levels are all above 0, keep the base at 0 and proceed with adding the levels above
+                elevations = new double[count + 1];
+
+                for (int i = 0; i < count; i++)
+                {
+                    elevations[i + 1] = levelList[i].Elevation;
+                }
+            }
+            
 #else
             double baseEl = levelList[0].Elevation;
             double prevEl = baseEl;


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #313 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/Ed6BQd-J0YVFpOvCapmRme4B78umJf1o-av4JswmxqT9YA?e=BTnKR0

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Change made so that the level provided with the lowest elevation is always considered the base level. No longer inserting base at level 0.

 ### Additional comments
<!-- As required -->
