### PR TITLE
Renamed RigidLink master/slave to primary/secondary

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Link.cs
+++ b/Etabs_Adapter/CRUD/Create/Link.cs
@@ -48,20 +48,18 @@ namespace BH.Adapter.ETABS
         private bool CreateObject(RigidLink bhLink)
         {
             bool success = true;
-            int retA = 0;
 
             List<string> linkIds = new List<string>();
 
             LinkConstraint constraint = bhLink.Constraint;//not used yet
-            Node masterNode = bhLink.MasterNode;
-            List<Node> slaveNodes = bhLink.SlaveNodes;
-            bool multiSlave = slaveNodes.Count() == 1 ? false : true;
+            Node primaryNode = bhLink.PrimaryNode;
+            List<Node> secondaryNodes = bhLink.SecondaryNodes;
 
-            for (int i = 0; i < slaveNodes.Count(); i++)
+            for (int i = 0; i < secondaryNodes.Count(); i++)
             {
                 string name = "";
 
-                retA = m_model.LinkObj.AddByPoint(masterNode.CustomData[AdapterIdName].ToString(), slaveNodes[i].CustomData[AdapterIdName].ToString(), ref name, false, constraint.DescriptionOrName());
+                m_model.LinkObj.AddByPoint(primaryNode.CustomData[AdapterIdName].ToString(), secondaryNodes[i].CustomData[AdapterIdName].ToString(), ref name, false, constraint.DescriptionOrName());
 
                 linkIds.Add(name);
             }

--- a/Etabs_Adapter/CRUD/Read/Link.cs
+++ b/Etabs_Adapter/CRUD/Read/Link.cs
@@ -59,20 +59,20 @@ namespace BH.Adapter.ETABS
 
             ids = FilterIds(ids, names);
 
-            //read master-multiSlave nodes if these were initially created from (non-etabs)BHoM side
+            //read primary-multiSecondary nodes if these were initially created from (non-etabs)BHoM side
             Dictionary<string, List<string>> idDict = new Dictionary<string, List<string>>();
-            string[] masterSlaveId;
+            string[] primarySecondaryId;
 
             foreach (string id in ids)
             {
-                masterSlaveId = id.Split(new[] { ":::" }, StringSplitOptions.None);
-                if (masterSlaveId.Count() > 1)
+                primarySecondaryId = id.Split(new[] { ":::" }, StringSplitOptions.None);
+                if (primarySecondaryId.Count() > 1)
                 {
-                    //has multi slaves
-                    if (idDict.ContainsKey(masterSlaveId[0]))
-                        idDict[masterSlaveId[0]].Add(masterSlaveId[1]);
+                    //has plural secondaries
+                    if (idDict.ContainsKey(primarySecondaryId[0]))
+                        idDict[primarySecondaryId[0]].Add(primarySecondaryId[1]);
                     else
-                        idDict.Add(masterSlaveId[0], new List<string>() { masterSlaveId[1] });
+                        idDict.Add(primarySecondaryId[0], new List<string>() { primarySecondaryId[1] });
                 }
                 else
                 {
@@ -96,8 +96,8 @@ namespace BH.Adapter.ETABS
                     m_model.LinkObj.GetPoints(kvp.Key, ref startId, ref endId);
 
                     List<Node> endNodes = ReadNode(new List<string> { startId, endId });
-                    bhLink.MasterNode = endNodes[0];
-                    bhLink.SlaveNodes = new List<Node>() { endNodes[1] };
+                    bhLink.PrimaryNode = endNodes[0];
+                    bhLink.SecondaryNodes = new List<Node>() { endNodes[1] };
                 }
                 else
                 {
@@ -119,9 +119,9 @@ namespace BH.Adapter.ETABS
                     }
 
                     List<Node> endNodes = ReadNode(nodeIdsToRead);
-                    bhLink.MasterNode = endNodes[0];
+                    bhLink.PrimaryNode = endNodes[0];
                     endNodes.RemoveAt(0);
-                    bhLink.SlaveNodes = endNodes;
+                    bhLink.SecondaryNodes = endNodes;
                 }
                 string propName = "";
                 m_model.LinkObj.GetProperty(kvp.Key, ref propName);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
/BHoM/BHoM/pull/961


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue921-RigidLink%20property%20rename/Test%20Rigid%20Links%20-%20multi%20adapter.gh?csf=1&web=1&e=iDXtGs

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
