### PR TITLE
Update to TaperedProfile functionality inline with Geometry_oM updates

### DIFF
--- a/Etabs_Adapter/CRUD/Create/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SectionProperty.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.SectionProperties;
 using BH.Engine.Geometry;
+using BH.Engine.Spatial;
 using BH.Engine.Structure;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;

--- a/Etabs_Adapter/CRUD/Create/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SectionProperty.cs
@@ -135,7 +135,7 @@ namespace BH.Adapter.ETABS
             double[] length = new double[num];
 
             // Formatt section names and positions to ETABS standard
-            decimal[] positions = profile.Profiles.Keys.ToArray();
+            double[] positions = profile.Profiles.Keys.ToArray();
             for (int i = 0; i < num; i++)
             {
                 segmentStartProfile[i] = sectionName + "_SubSection" + (i).ToString();

--- a/Etabs_Adapter/CRUD/Create/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SectionProperty.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.SectionProperties;
+using BH.Engine.Geometry;
 using BH.Engine.Structure;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;
@@ -123,6 +124,9 @@ namespace BH.Adapter.ETABS
 
         private void SetProfile(TaperedProfile profile, string sectionName, IMaterialFragment material)
         {
+            //Map Position domain to [0,1]
+            profile.MapPositionDomain();
+            
             // Create a section for each sub profile
             IProfile[] profiles = profile.Profiles.Values.ToArray();
             for (int i = 0; i < profiles.Length; i++)

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -176,13 +176,13 @@ namespace BH.Adapter.ETABS
                             }
 
                             // convert length values to relative positions between 0 and 1
-                            List<decimal> positions = new List<decimal>() { 0 };
+                            List<double> positions = new List<double>() { 0 };
                             for (int i = 0; i < myLength.Length; i++)
                             {
-                                positions.Add(System.Convert.ToDecimal(myLength[i]) + positions[i]);
+                                positions.Add(System.Convert.ToDouble(myLength[i]) + positions[i]);
                             }
                             double totLength = myLength.Sum();
-                            positions = positions.Select(x => x / System.Convert.ToDecimal(totLength)).ToList();
+                            positions = positions.Select(x => x / System.Convert.ToDouble(totLength)).ToList();
 
                             // Getting a Profile from a name in the propList
                             Func<string, IProfile> getProfile = sectionName =>
@@ -205,7 +205,7 @@ namespace BH.Adapter.ETABS
                                 if (startSec[i] != endSec[i - 1])
                                 {
                                     profiles.Insert(i + 1, getProfile(startSec[i]));
-                                    positions.Insert(i + 1, positions[i] + System.Convert.ToDecimal(Tolerance.Distance));
+                                    positions.Insert(i + 1, positions[i] + System.Convert.ToDouble(Tolerance.Distance));
                                 }
                             }
 
@@ -223,13 +223,16 @@ namespace BH.Adapter.ETABS
                                 }
                             }
 
+                            //Etabs can only accept sections that vary linearly along it's length
+                            List<int> interpolationOrder = Enumerable.Repeat(1, positions.Count - 1).ToList();
+
                             if (profiles.Any(x => x == null))
                             {
                                 Engine.Reflection.Compute.RecordNote("Tapered profiles require the sub-profiles to be geometrically defined, they can not be any kind of explicit section.");
                             }
                             else
                             {
-                                dimensions = Engine.Geometry.Create.TaperedProfile(positions, profiles);
+                                dimensions = Engine.Geometry.Create.TaperedProfile(positions, profiles, interpolationOrder);
                             }
                         break;
                         case eFramePropType.Joist:


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/992
https://github.com/BHoM/BHoM_Engine/pull/1980
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #346 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
From previous PR:
https://burohappold.sharepoint.com/:f:/s/BHoM/Egd4_nUinPtCo7NtgkKXJewBqF3dWOa7Ul7Tc2GtPtCfpA?e=WYGtAr
General script with a variety of sections:
https://burohappold.sharepoint.com/:f:/s/BHoM/EsoGNizz8VZAn_h4VNRhhuwBTuj98dVj4ZDK3-84ID8KGw?e=VTSafM

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional Comments
- Based on comments in the code I have assumed the `interpolationOrder` can only be linear.