### PR TITLE
Fix force refresh for Etabs18

### DIFF
--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -138,6 +138,7 @@ namespace BH.Adapter.ETABS
             //If a more elegant way can be found to do this, this should be changed.
             m_model.SelectObj.All();
             m_model.EditGeneral.Move(1, 0, 0);
+            m_model.SelectObj.All();
             m_model.EditGeneral.Move(-1, 0, 0);
             m_model.SelectObj.ClearSelection();
             return true;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #362 

 <!-- Add short description of what has been fixed -->

Fixing issue with the force refresh, in particular for ETABS18. Adding a second SelectAll before moving all elements back.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Eha-mq-0l55KryMeBe543YkBf2M6CQUaOaL6xgKfeFLg6Q?e=chvV7S

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
