### PR TITLE
ETABS_Engine: Capitalise ETABS_Engine assembly name

### DIFF
--- a/ETABS_Engine/ETABS_Engine.csproj
+++ b/ETABS_Engine/ETABS_Engine.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.Adapters.ETABS</RootNamespace>
-    <AssemblyName>Etabs_Engine</AssemblyName>
+    <AssemblyName>ETABS_Engine</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #367

 <!-- Add short description of what has been fixed -->
Changes assembly name from Etabs_Engine to ETABS_Engine to match the capitalisation used throughout the toolkit. This means that Etabs_Engine.dll will now be called ETABS_Engine.dll. Note that files in Windows are not case sensitive, so if Etabs_Engine.dll already exists when building, this name will be kept - but this should also mean that this change shouldn't cause any File Not Found errors or similar.
