### PR TITLE
Align to BHoM_Adapter's AdapterId() method change

### DIFF
--- a/Etabs_Adapter/CRUD/Update/Bar.cs
+++ b/Etabs_Adapter/CRUD/Update/Bar.cs
@@ -58,15 +58,14 @@ namespace BH.Adapter.ETABS
 
             foreach (Bar bhBar in bhBars)
             {
-                object id = bhBar.AdapterId(typeof(ETABSId));
+                string id = bhBar.AdapterId<string>(typeof(ETABSId));
                 if (id != null)
                 {
                     Engine.Reflection.Compute.RecordWarning("The Bar must have an ETABS adapter id to be updated.");
                     continue;
                 }
 
-                string name = id as string;
-                if (!names.Contains(name))
+                if (!names.Contains(id))
                 {
                     Engine.Reflection.Compute.RecordWarning("The Bar must be present in ETABS to be updated.");
                     continue;

--- a/Etabs_Adapter/CRUD/Update/Bar.cs
+++ b/Etabs_Adapter/CRUD/Update/Bar.cs
@@ -74,7 +74,7 @@ namespace BH.Adapter.ETABS
 #if Debug16 || Release16
                 string start = "";
                 string end = "";
-                m_model.FrameObj.GetPoints(name, ref start, ref end);
+                m_model.FrameObj.GetPoints(id, ref start, ref end);
 
                 if (GetAdapterId<string>(bhBar.StartNode) != start ||
                     GetAdapterId<string>(bhBar.EndNode) != end)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Adapter/pull/287
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #379 

<!-- Add short description of what has been fixed -->
The ETABS adapter was relying on the non-generic `AdapterId()` method to get the Id of the objects. While this is not wrong per se, that method has now been renamed to `AdapterIds()` (note the s) to highlight the fact that it may return _more than only one Id, depending on whether multiple Ids have been stored on the object_.  
As this adapter currently does not need to use that feature, this PR simply replaces it with calls to `AdapterId<T>()`.

### Test files
<!-- Link to test files to validate the proposed changes -->
Testing of existing functionality is needed to make sure that everything works as before.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->