### PR TITLE
Add support for future ETABS versions

### DIFF
--- a/Etabs_Adapter/AdapterActions/Execute.cs
+++ b/Etabs_Adapter/AdapterActions/Execute.cs
@@ -29,23 +29,23 @@ using BH.oM.Base;
 using BH.oM.Adapter.Commands;
 using BH.oM.Structure.Loads;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter
-#elif Debug18 || Release18
-    public partial class ETABS18Adapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter
+#elif Debug17 || Release17
+    public partial class ETABS17Adapter
+#else
+    public partial class ETABSAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Bar.cs
+++ b/Etabs_Adapter/CRUD/Create/Bar.cs
@@ -34,22 +34,16 @@ using BH.Engine.Structure;
 using BH.oM.Geometry;
 using BH.oM.Structure.Constraints;
 using BH.Engine.Base;
-#if Debug17 || Release17
-    using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/
@@ -126,7 +120,8 @@ namespace BH.Adapter.ETABS
             string name = GetAdapterId<string>(bhBar);
 
             // Needed rigth after create as well as AddByPoint flipps the Bar if it feels like it
-#if Debug17 || Release17 || Debug18 || Release18
+#if Debug16 || Release16
+#else
             m_model.EditFrame.ChangeConnectivity(name, GetAdapterId<string>(bhBar.StartNode), GetAdapterId<string>(bhBar.EndNode));
 #endif
 

--- a/Etabs_Adapter/CRUD/Create/Bar.cs
+++ b/Etabs_Adapter/CRUD/Create/Bar.cs
@@ -120,8 +120,7 @@ namespace BH.Adapter.ETABS
             string name = GetAdapterId<string>(bhBar);
 
             // Needed rigth after create as well as AddByPoint flipps the Bar if it feels like it
-#if Debug16 || Release16
-#else
+#if Debug16 == false && Release16 == false
             m_model.EditFrame.ChangeConnectivity(name, GetAdapterId<string>(bhBar.StartNode), GetAdapterId<string>(bhBar.EndNode));
 #endif
 

--- a/Etabs_Adapter/CRUD/Create/Diaphragm.cs
+++ b/Etabs_Adapter/CRUD/Create/Diaphragm.cs
@@ -26,22 +26,15 @@ using BH.Engine.Adapter;
 using BH.oM.Adapters.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Error.cs
+++ b/Etabs_Adapter/CRUD/Create/Error.cs
@@ -25,22 +25,16 @@ using System.Linq;
 using BH.Engine.Adapter;
 using BH.oM.Adapters.ETABS;
 using System;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Level.cs
+++ b/Etabs_Adapter/CRUD/Create/Level.cs
@@ -27,22 +27,16 @@ using BH.Engine.Adapter;
 using BH.Engine.Adapters.ETABS;
 using BH.oM.Adapters.ETABS;
 using BH.oM.Spatial.SettingOut;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Link.cs
+++ b/Etabs_Adapter/CRUD/Create/Link.cs
@@ -28,22 +28,16 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.Engine.Structure;
 using BH.Engine.Adapters.ETABS;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Load.cs
+++ b/Etabs_Adapter/CRUD/Create/Load.cs
@@ -30,22 +30,16 @@ using BH.oM.Structure.Loads;
 using BH.Engine.Spatial;
 using BH.Engine.Adapters.ETABS;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Create/Loadcase.cs
@@ -27,22 +27,22 @@ using BH.oM.Adapters.ETABS;
 using System;
 using BH.oM.Structure.Loads;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Material.cs
+++ b/Etabs_Adapter/CRUD/Create/Material.cs
@@ -30,22 +30,22 @@ using BH.Engine.Adapters.ETABS;
 using System.ComponentModel;
 using System;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Node.cs
+++ b/Etabs_Adapter/CRUD/Create/Node.cs
@@ -32,12 +32,12 @@ using BH.oM.Geometry;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/Panel.cs
+++ b/Etabs_Adapter/CRUD/Create/Panel.cs
@@ -32,22 +32,15 @@ using BH.Engine.Adapters.ETABS;
 using BH.oM.Adapters.ETABS.Elements;
 using BH.oM.Geometry;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SectionProperty.cs
@@ -34,20 +34,15 @@ using BH.oM.Structure.Fragments;
 using BH.Engine.Base;
 using System;
 
-#if Debug17 || Release17
-using ETABSv17;
-#else
-    using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
 

--- a/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -29,22 +29,22 @@ using BH.Engine.Base;
 using BH.Engine.Adapter;
 using BH.oM.Adapters.ETABS.Fragments;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Create/_Create.cs
+++ b/Etabs_Adapter/CRUD/Create/_Create.cs
@@ -28,23 +28,14 @@ using BH.oM.Adapters.ETABS.Elements;
 using BH.oM.Adapter;
 using BH.oM.Base;
 
-
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
-
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
 

--- a/Etabs_Adapter/CRUD/Delete/_Delete.cs
+++ b/Etabs_Adapter/CRUD/Delete/_Delete.cs
@@ -40,12 +40,12 @@ using System.Collections;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Bar.cs
+++ b/Etabs_Adapter/CRUD/Read/Bar.cs
@@ -33,22 +33,16 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
 using BH.Engine.Adapters.ETABS;
 using BH.oM.Geometry;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Grid.cs
+++ b/Etabs_Adapter/CRUD/Read/Grid.cs
@@ -32,22 +32,16 @@ using BH.oM.Spatial.SettingOut;
 using BH.oM.Geometry;
 using System.ComponentModel;
 using BH.Engine.Geometry;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Level.cs
+++ b/Etabs_Adapter/CRUD/Read/Level.cs
@@ -30,22 +30,16 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Spatial.SettingOut;
 using BH.Engine.Adapters.ETABS;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Link.cs
+++ b/Etabs_Adapter/CRUD/Read/Link.cs
@@ -32,22 +32,22 @@ using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.Engine.Adapters.ETABS;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Load.cs
+++ b/Etabs_Adapter/CRUD/Read/Load.cs
@@ -35,22 +35,22 @@ using BH.oM.Geometry;
 using BH.Engine.Spatial;
 using BH.Engine.Structure;
 using BH.Engine.Adapters.ETABS;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Read/Loadcase.cs
@@ -30,22 +30,22 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Loads;
 using BH.Engine.Adapters.ETABS;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Material.cs
+++ b/Etabs_Adapter/CRUD/Read/Material.cs
@@ -29,23 +29,23 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.MaterialFragments;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 using BH.Engine.Adapters.ETABS;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Mesh.cs
+++ b/Etabs_Adapter/CRUD/Read/Mesh.cs
@@ -31,23 +31,16 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SurfaceProperties;
 using BH.Engine.Structure;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 using BH.oM.Geometry;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Node.cs
+++ b/Etabs_Adapter/CRUD/Read/Node.cs
@@ -31,22 +31,16 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
+
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Panel.cs
+++ b/Etabs_Adapter/CRUD/Read/Panel.cs
@@ -36,22 +36,15 @@ using BH.Engine.Geometry;
 using BH.oM.Adapters.ETABS.Elements;
 using BH.Engine.Structure;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
@@ -30,12 +30,12 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Geometry;
@@ -45,12 +45,12 @@ using BH.oM.Structure.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
@@ -30,24 +30,17 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -30,12 +30,12 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Geometry;
@@ -45,12 +45,12 @@ using BH.oM.Structure.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -30,12 +30,12 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;
@@ -43,12 +43,12 @@ using BH.oM.Structure.Elements;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/PierAndSpandrelResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/PierAndSpandrelResults.cs
@@ -30,13 +30,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;
 using BH.oM.Adapters.ETABS.Results;
@@ -44,12 +37,12 @@ using BH.oM.Adapters.ETABS.Requests;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/Result.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/Result.cs
@@ -30,13 +30,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 using BH.oM.Adapters.ETABS.Results;
 using BH.oM.Structure.Loads;
 using BH.oM.Data.Requests;
@@ -47,12 +40,12 @@ using BH.oM.Base;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
 

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -34,22 +34,22 @@ using BH.oM.Geometry;
 using BH.oM.Spatial.ShapeProfiles;
 using BH.Engine.Structure;
 using BH.oM.Structure.Fragments;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SurfaceProperty.cs
@@ -33,22 +33,22 @@ using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.Fragments;
 using BH.oM.Adapters.ETABS.Fragments;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/_Read.cs
+++ b/Etabs_Adapter/CRUD/Read/_Read.cs
@@ -36,26 +36,18 @@ using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Analytical.Results;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 using BH.oM.Adapter;
 using System.ComponentModel;
 using BH.oM.Data.Requests;
-using BH.oM.Base;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/Bar.cs
+++ b/Etabs_Adapter/CRUD/Update/Bar.cs
@@ -26,22 +26,15 @@ using BH.Engine.Adapter;
 using BH.oM.Adapters.ETABS;
 using BH.oM.Structure.Elements;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/Material.cs
+++ b/Etabs_Adapter/CRUD/Update/Material.cs
@@ -27,22 +27,22 @@ using BH.oM.Adapters.ETABS;
 using BH.Engine.Structure;
 using BH.oM.Structure.MaterialFragments;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/Node.cs
+++ b/Etabs_Adapter/CRUD/Update/Node.cs
@@ -30,12 +30,12 @@ using BH.Engine.Adapters.ETABS;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/Panel.cs
+++ b/Etabs_Adapter/CRUD/Update/Panel.cs
@@ -33,12 +33,12 @@ using BH.Engine.Structure;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Update/SectionProperty.cs
@@ -29,22 +29,15 @@ using BH.Engine.Structure;
 using BH.oM.Structure.Fragments;
 using BH.Engine.Base;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Update/SurfaceProperty.cs
@@ -27,22 +27,15 @@ using BH.oM.Adapters.ETABS;
 using BH.Engine.Structure;
 using BH.oM.Structure.SurfaceProperties;
 
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
-using ETABS2016;
-#endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Update/_Update.cs
+++ b/Etabs_Adapter/CRUD/Update/_Update.cs
@@ -35,12 +35,12 @@ using BH.oM.Base;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -28,7 +28,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.ComponentModel;
 using BH.oM.Base;
+using BH.oM.Base.Attributes;
 using BH.Engine.Units;
 #if Debug16 || Release16
 using ETABS2016;
@@ -41,10 +43,13 @@ using ETABSv1;
 namespace BH.Adapter.ETABS
 {
 #if Debug16 || Release16
+    [Description("Class for handling connection to ETABS version 2016.")]
     public partial class ETABS2016Adapter : BHoMAdapter
 #elif Debug17 || Release17
+    [Description("Class for handling connection to ETABS version 17.")]
    public partial class ETABS17Adapter : BHoMAdapter
 #else
+    [Description("Class for handling connection to ETABS version 18 and later.")]
     public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
@@ -60,11 +65,18 @@ namespace BH.Adapter.ETABS
         /**** Constructors                              ****/
         /***************************************************/
 
+
+        [Input("filePath","Optional file path. If empty, or not a valid file path. If empty, a new file will be created unless ETABS is already running.",typeof(FilePathAttribute))]
+        [Input("etabsSetting", "Controling various settings of the adapter.")]
+        [Input("active", "Toggle to true to activate the adapter. If ETABS is running, the adapter will connect to the running instance. If ETABS is not running, the adapter will start up a new instance of ETABS.")]
 #if Debug16 || Release16
+       [Description("Creates an adapter to ETABS 2016. For connection to ETABS v18 or later use the ETABSAdapter.  For connection to ETABS v17 use the ETABS17Adapter. Earlier versions not supported.")]
         public ETABS2016Adapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #elif Debug17 || Release17
+        [Description("Creates an adapter to ETABS v17. For connection to ETABS v18 or later use the ETABSAdapter. For connection to ETABS 2016 use the ETABS2016Adapter. Earlier versions not supported.")]
         public ETABS17Adapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #else
+        [Description("Creates an adapter to ETABS version 18 or later. For connection to ETABS v17 use the ETABS17Adapter. For connection to ETABS 2016 use the ETABS2016Adapter. Earlier versions not supported.")]
         public ETABSAdapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #endif
         {

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -30,22 +30,22 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.Engine.Units;
-#if Debug17 || Release17
-using ETABSv17;
-#elif Debug18 || Release18
-using ETABSv1;
-#else
+#if Debug16 || Release16
 using ETABS2016;
+#elif Debug17 || Release17
+using ETABSv17;
+#else
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/
@@ -60,12 +60,12 @@ namespace BH.Adapter.ETABS
         /**** Constructors                              ****/
         /***************************************************/
 
-#if Debug17 || Release17
-        public ETABS17Adapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
-#elif Debug18 || Release18
-        public ETABS18Adapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
-#else
+#if Debug16 || Release16
         public ETABS2016Adapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
+#elif Debug17 || Release17
+        public ETABS17Adapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
+#else
+        public ETABSAdapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #endif
         {
             //Initialisation
@@ -80,15 +80,15 @@ namespace BH.Adapter.ETABS
 
                 //string pathToETABS = System.IO.Path.Combine(Environment.GetEnvironmentVariable("PROGRAMFILES"), "Computers and Structures", "ETABS 2016", "ETABS.exe");
                 //string pathToETABS = System.IO.Path.Combine("C:","Program Files", "Computers and Structures", "ETABS 2016", "ETABS.exe");
-#if Debug17 || Release17
+#if Debug16 || Release16
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 17\ETABS.exe";
-                cHelper helper = new ETABSv17.Helper();
-#elif Debug18 || Release18
+                cHelper helper = new ETABS2016.Helper();
+#elif Debug17 || Release17
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 18\ETABS.exe";
-                cHelper helper = new ETABSv1.Helper();
+                cHelper helper = new ETABSv17.Helper();
 #else
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 2016\ETABS.exe";
-                cHelper helper = new ETABS2016.Helper();
+                cHelper helper = new ETABSv1.Helper();
 #endif
 
 

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -31,7 +31,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.ETABS</RootNamespace>
-    <AssemblyName>ETABS18_Adapter</AssemblyName>
+    <AssemblyName>ETABS_Adapter</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -64,7 +64,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.ETABS</RootNamespace>
-    <AssemblyName>ETABS18_Adapter</AssemblyName>
+    <AssemblyName>ETABS_Adapter</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -131,22 +131,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;Debug16</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>ETABS2016_Adapter</AssemblyName>
+    <AssemblyName>ETABS_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;Release16</DefineConstants>
+    <DefineConstants>TRACE;Release18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>Etabs2016_Adapter</AssemblyName>
+    <AssemblyName>Etabs_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug16|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -191,22 +191,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;Debug16</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;Debug18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>ETABS2016_Adapter</AssemblyName>
+    <AssemblyName>ETABS_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;Release16</DefineConstants>
+    <DefineConstants>TRACE;Release18</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>ETABS2016_Adapter</AssemblyName>
+    <AssemblyName>ETABS_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug18|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -411,6 +411,7 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Versioning_51.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Etabs_Adapter/Types/Comparer.cs
+++ b/Etabs_Adapter/Types/Comparer.cs
@@ -37,12 +37,12 @@ using BH.Engine.Structure;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
 

--- a/Etabs_Adapter/Types/DependencyTypes.cs
+++ b/Etabs_Adapter/Types/DependencyTypes.cs
@@ -33,12 +33,12 @@ using System.Collections.Generic;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         /***************************************************/

--- a/Etabs_Adapter/Types/NextIndex.cs
+++ b/Etabs_Adapter/Types/NextIndex.cs
@@ -30,12 +30,12 @@ using System.Threading.Tasks;
 
 namespace BH.Adapter.ETABS
 {
-#if Debug17 || Release17
-    public partial class ETABS17Adapter : BHoMAdapter
-#elif Debug18 || Release18
-   public partial class ETABS18Adapter : BHoMAdapter
-#else
+#if Debug16 || Release16
     public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
 #endif
     {
         private Dictionary<Type, string> idDictionary = new Dictionary<Type, string>();

--- a/Etabs_Adapter/Versioning_51.json
+++ b/Etabs_Adapter/Versioning_51.json
@@ -1,0 +1,27 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+      "BH.Adapter.ETABS.ETABS18Adapter": "BH.Adapter.ETABS.ETABSAdapter"
+
+    },
+    "ToOld": {
+      "BH.Adapter.ETABS.ETABSAdapter": "BH.Adapter.ETABS.ETABS18Adapter"
+    }
+  },
+  "Property": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "MessageForDeleted": {
+  },
+  "MessageForNoUpgrade": {
+  }
+}

--- a/altConfigs.txt
+++ b/altConfigs.txt
@@ -1,0 +1,3 @@
+BHoM/ETABS_Toolkit/Debug
+BHoM/ETABS_Toolkit/Debug16
+BHoM/ETABS_Toolkit/Debug17


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #391 

 <!-- Add short description of what has been fixed -->

WIth the API changed for Etabs from version 18 and onwards, the API is stated to work for future versions of the software. Hence, refactoring the adapter to reflect this. The ETABS18ADapter is renamed ETABSAdapter, as it should work for 18, 19 and future versions, with no requirements for special builds.

Keeping the 2016 and 17 adapters as is for backwards compatibility with those versions of the software.

The initialisation code for starting ETABS has been changed for the new ETABSAdapter to start the latest version of ETABS installed on the system, rather than pointing at a particular source folder. This means this part of the code does not need to be updated for every release of the software, and mimics what has been done for SAP2000.

Also cleaned up a significant amount of unrequired usings of the api reference to simplify the code.
 ### Test files
<!-- Link to test files to validate the proposed changes -->

Specific testfile to test versioning in here. To test the versioning, make sure you manually delete the Etabs18_adapter.dll file from the assemblies folder in ProgramData. On this PR the EtabsAdapter will be marked as prototype, but that will not be the case as soon as the dlls have been updated in the installer.:

https://burohappold.sharepoint.com/:f:/s/BHoM/EjQQjb2k76pDs0Nkecwaq4IBOHDMKP_yNS4dcZnx3nYpVA?e=ubLiiO

The ETABSAdapter should work as the previous ETABS18ADapter did. Regular test scripts or project scripts good to use as a test-case.

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Rename ETABS18Adapter to ETABSAdapter
- Make sure the ETABSAdapter starts the latest available version of ETABS on the computer

 ### Additional comments
<!-- As required -->
