### PR TITLE
Fix Etabs unlock/delete results function

### DIFF
--- a/Etabs_Adapter/AdapterActions/Execute.cs
+++ b/Etabs_Adapter/AdapterActions/Execute.cs
@@ -124,7 +124,14 @@ namespace BH.Adapter.ETABS
 
         public bool RunCommand(ClearResults command)
         {
-            return m_model.Analyze.DeleteResults("", true) == 0;
+            if (m_model.Analyze.DeleteResults("", true) == 0)
+            {
+                return m_model.SetModelIsLocked(false) == 0;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR

Resolves #350

 ### Test files
<!-- Link t[o test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/Installers/Scripts/Burohappold_BHoM_v6.3/Structures%20-%20Execute%20commands/BuroHappold_BHoM_v6.3.beta_ExecuteCommands.gh?csf=1&web=1&e=0fKUaa

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed Etabs `ClearResults` function so the model becomes unlocked.

 ### Additional comments
<!-- As required -->
Previous `ClearResults` command does not work but still return `true`.
Fix this bug by referring to the code of sap2000 toolkit.