### PR TITLE
Fixes the issue of failing to launch ETABS application when the ETABS adapter is toggled on

### DIFF
--- a/ETABS_Toolkit.sln
+++ b/ETABS_Toolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 14 for Windows Desktop
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETABS_Adapter", "Etabs_Adapter\ETABS_Adapter.csproj", "{895E2AB0-E349-4C1A-9098-51A46CD3A955}"
 EndProject
@@ -41,8 +41,8 @@ Global
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug17|Any CPU.Build.0 = Debug17|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug17|x64.ActiveCfg = Debug17|x64
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug17|x64.Build.0 = Debug17|x64
-		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|Any CPU.ActiveCfg = Debug18|Any CPU
-		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|Any CPU.Build.0 = Debug18|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|Any CPU.ActiveCfg = Debug|Any CPU
+		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|Any CPU.Build.0 = Debug|Any CPU
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|x64.ActiveCfg = Debug18|x64
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Debug18|x64.Build.0 = Debug18|x64
 		{895E2AB0-E349-4C1A-9098-51A46CD3A955}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Etabs_Adapter/AdapterActions/Execute.cs
+++ b/Etabs_Adapter/AdapterActions/Execute.cs
@@ -34,7 +34,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 

--- a/Etabs_Adapter/CRUD/Create/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Create/Loadcase.cs
@@ -32,7 +32,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Create/Material.cs
+++ b/Etabs_Adapter/CRUD/Create/Material.cs
@@ -36,7 +36,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -34,7 +34,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Link.cs
+++ b/Etabs_Adapter/CRUD/Read/Link.cs
@@ -37,7 +37,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Load.cs
+++ b/Etabs_Adapter/CRUD/Read/Load.cs
@@ -40,7 +40,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Read/Loadcase.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Material.cs
+++ b/Etabs_Adapter/CRUD/Read/Material.cs
@@ -34,7 +34,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 using BH.Engine.Adapters.ETABS;
 

--- a/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Geometry;

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Geometry;

--- a/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -39,7 +39,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SurfaceProperty.cs
@@ -38,7 +38,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Update/Material.cs
+++ b/Etabs_Adapter/CRUD/Update/Material.cs
@@ -32,7 +32,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -37,7 +37,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using ETABSv1;
+using CSiAPIv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -230,37 +230,37 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Adapter_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Adapter_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Adapter_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Analytical_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Analytical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Architecture_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Architecture_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Architecture_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Adapter">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -268,12 +268,12 @@
       <HintPath>..\packages\CSiAPIv1.1.0.0\lib\net\CSiAPIv1.dll</HintPath>
     </Reference>
     <Reference Include="Data_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Dimensional_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -289,41 +289,41 @@
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Physical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Spatial_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Spatial_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Spatial_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Spatial_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Spatial_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Spatial_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_AdapterModules">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Structure_AdapterModules.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_AdapterModules.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Structure_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Structure_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -336,7 +336,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Units_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Units_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Units_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -264,6 +264,9 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="CSiAPIv1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=8a93c9e72eabf762, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSiAPIv1.1.0.0\lib\net\CSiAPIv1.dll</HintPath>
+    </Reference>
     <Reference Include="Data_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
@@ -276,11 +279,6 @@
     </Reference>
     <Reference Include="ETABS2016, Version=16.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CSI_ETABSv2016_x64.1.0.3\lib\ETABS2016.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="ETABSv1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=453d728ef24c6f5e, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSI_ETABSv18_x64.1.0.0\lib\ETABSv1.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
@@ -419,7 +417,7 @@
       xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
       xcopy "$(TargetDir)ETABS2016.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
 xcopy "$(TargetDir)ETABSv17.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
-xcopy "$(TargetDir)ETABSv1.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "$(TargetDir)CSiAPIv1.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Etabs_Adapter/packages.config
+++ b/Etabs_Adapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CSI_ETABSv17_x64" version="1.0.3" targetFramework="net452" />
-  <package id="CSI_ETABSv18_x64" version="1.0.0" targetFramework="net452" />
   <package id="CSI_ETABSv2016_x64" version="1.0.3" targetFramework="net452" />
+  <package id="CSiAPIv1" version="1.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
 Closes #420 

 <!-- Add short description of what has been fixed -->

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/ETABS_Toolkit/%23420%20Issue%20Etabs%20Adapter%20is%20not%20able%20to%20launch%20Etabs/240205%20Etabs_Launch%20fail_Resolved.gh?csf=1&web=1&e=IGX2gI

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Replaced ETABSv1 with CSiAPIv1 NuGet package. This causes the ETABS Application to be launched when the adapter component is toggled on.

 ### Additional comments
<!-- As required -->
ETABS adapter would fail to launch ETABS (Version 19) as reported by the user. The push/pull would only work when the ETABS application is already opened by the user manually. The reported behavior is also observed in ETABS (Version 20) which is the version installed in my machine. Replacing of NuGet Package with more updated version (which references CSI ETABS API) fixed this issue.