### PR TITLE
Fix ETABS Levels Pushing

### DIFF
--- a/Etabs_Adapter/Types/DependencyTypes.cs
+++ b/Etabs_Adapter/Types/DependencyTypes.cs
@@ -50,11 +50,11 @@ namespace BH.Adapter.ETABS
         {
             DependencyTypes = new Dictionary<Type, List<Type>>
             {
-                {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node),typeof(Level)} },
+                {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node)} },
                 {typeof(ISectionProperty), new List<Type> { typeof(IMaterialFragment) } },
-                {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Level) } },
+                {typeof(Panel), new List<Type> { typeof(ISurfaceProperty)} },
                 {typeof(ISurfaceProperty), new List<Type> { typeof(IMaterialFragment) } },
-                {typeof(RigidLink), new List<Type> { typeof(Node), typeof(LinkConstraint), typeof(Level) } },
+                {typeof(RigidLink), new List<Type> { typeof(Node), typeof(LinkConstraint)} },
                 {typeof(ILoad), new List<Type> {typeof(Loadcase) } },
                 {typeof(IElementLoad<Bar>), new List<Type>{ typeof(Bar)} },
                 {typeof(IElementLoad<Node>), new List<Type>{ typeof(Node)} }

--- a/Etabs_Adapter/Types/DependencyTypes.cs
+++ b/Etabs_Adapter/Types/DependencyTypes.cs
@@ -30,6 +30,7 @@ using System;
 using BH.Engine.Adapter;
 using BH.oM.Adapters.ETABS;
 using System.Collections.Generic;
+using BH.oM.Spatial.SettingOut;
 
 namespace BH.Adapter.ETABS
 {
@@ -49,11 +50,11 @@ namespace BH.Adapter.ETABS
         {
             DependencyTypes = new Dictionary<Type, List<Type>>
             {
-                {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node) } },
+                {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node),typeof(Level)} },
                 {typeof(ISectionProperty), new List<Type> { typeof(IMaterialFragment) } },
-                {typeof(Panel), new List<Type> { typeof(ISurfaceProperty) } },
+                {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Level) } },
                 {typeof(ISurfaceProperty), new List<Type> { typeof(IMaterialFragment) } },
-                {typeof(RigidLink), new List<Type> { typeof(Node), typeof(LinkConstraint) } },
+                {typeof(RigidLink), new List<Type> { typeof(Node), typeof(LinkConstraint), typeof(Level) } },
                 {typeof(ILoad), new List<Type> {typeof(Loadcase) } },
                 {typeof(IElementLoad<Bar>), new List<Type>{ typeof(Bar)} },
                 {typeof(IElementLoad<Node>), new List<Type>{ typeof(Node)} }


### PR DESCRIPTION
### NOTE: Depends on 
[https://github.com/BHoM/BHoM_Adapter/compare/ETABS_Toolkit-%23435-FixLevelsPushing?expand=1](url)
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #435 

Dependency Types in the ETABS Toolkit have been previously modified but they have been re-instated to their original values. Levels are getting pushed first and before any other object as per ETABS requirements.
This is achieved by sorting Levels first directly in the BHoM adapter. See link to corresponding PR above.


 ### Changelog
No changes.


 ### Additional comments
<!-- As required -->
