### PR TITLE
Add Set Get Point Displacement Loads

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Load.cs
+++ b/Etabs_Adapter/CRUD/Create/Load.cs
@@ -320,6 +320,22 @@ namespace BH.Adapter.ETABS
             BH.Engine.Base.Compute.RecordWarning("ETABS handles gravity loads via loadcases, why only one gravity load per loadcase can be used. THis gravity load will be applied to all objects");
         }
 
+        /***************************************************/
+
+        public void SetLoad(PointDisplacement pointDisplacementLoad, bool replace)
+        {
+            double[] pdValues = new double[] { pointDisplacementLoad.Translation.X, pointDisplacementLoad.Translation.Y, pointDisplacementLoad.Translation.Z,
+                                               pointDisplacementLoad.Rotation.X, pointDisplacementLoad.Rotation.Y, pointDisplacementLoad.Rotation.Z};
+            int ret = 0;
+
+            foreach (Node node in pointDisplacementLoad.Objects.Elements)
+            {
+                string caseName = GetAdapterId<string>(pointDisplacementLoad.Loadcase);
+                string nodeName = GetAdapterId<string>(node);
+                ret = m_model.PointObj.SetLoadDispl(nodeName, caseName, ref pdValues, replace);
+            }
+        }
+
 
         /***************************************************/
         /****       Helper Methods                      ****/


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #459 

 It is now possible to push and pull Point Displacement Loads to/from ETABS (see below)

![GH Script - Success](https://github.com/user-attachments/assets/720fa806-79fd-4472-8b2f-8495cc43804a)


![ETABS Outputs - Success](https://github.com/user-attachments/assets/59f9c310-43f3-4645-9c2e-40dd025055a9)


 ### Test files
Grasshopper File
[https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23467-AddSetGetPointDisplacementLoad/Test%20Script.gh?csf=1&web=1&e=L6zLU9](url)
ETABS File
[https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23467-AddSetGetPointDisplacementLoad/Test%20Etabs%20Model.EDB?csf=1&web=1&e=UJENuT](url)

 ### Changelog

- Added SetLoad Method for Point Displacement Loads
- Added ReadLoad Method for Point Displacement Loads
