### PR TITLE
Add Get Joint Accelerations

### DIFF
--- a/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -40,6 +40,7 @@ using CSiAPIv1;
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;
 using BH.oM.Structure.Elements;
+using System.Xml.Linq;
 
 namespace BH.Adapter.ETABS
 {
@@ -68,6 +69,7 @@ namespace BH.Adapter.ETABS
                     return ReadNodeDisplacement(nodeIds);
                 case NodeResultType.NodeVelocity:
                 case NodeResultType.NodeAcceleration:
+                    return ReadNodeAcceleration(nodeIds);
                 default:
                     Engine.Base.Compute.RecordError("Result extraction of type " + request.ResultType + " is not yet supported");
                     return new List<IResult>();
@@ -78,9 +80,43 @@ namespace BH.Adapter.ETABS
         /**** Private method - Extraction methods       ****/
         /***************************************************/
 
-        private List<NodeResult> ReadNodeAcceleration(IList ids = null, IList cases = null)
+        private List<NodeAcceleration> ReadNodeAcceleration(List<string> nodeIds)
         {
-            throw new NotImplementedException("Node Acceleration results is not supported yet!");
+            //throw new NotImplementedException("Node Acceleration results is not supported yet!");
+
+            List<NodeAcceleration> nodeAccelerations = new List<NodeAcceleration>();
+
+            int resultCount = 0;
+            string[] loadcaseNames = null;
+            string[] objects = null;
+            string[] elm = null;
+            string[] stepType = null;
+            double[] stepNum = null;
+            double[] ux = null;
+            double[] uy = null;
+            double[] uz = null;
+            double[] rx = null;
+            double[] ry = null;
+            double[] rz = null;
+
+            for (int i = 0; i < nodeIds.Count; i++)
+            {
+                int ret = m_model.Results.JointAccAbs(nodeIds[i].ToString(), eItemTypeElm.ObjectElm, ref resultCount, ref objects, ref elm, ref loadcaseNames,
+                                                      ref stepType, ref stepNum, ref ux, ref uy, ref uz, ref rx, ref ry, ref rz);
+                if (ret == 0)
+                {
+                    for (int j = 0; j < resultCount; j++)
+                    {
+                        int mode;
+                        double timeStep;
+                        GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
+                        NodeAcceleration na = new NodeAcceleration(nodeIds[i], loadcaseNames[j], mode, timeStep, oM.Geometry.Basis.XY, ux[j], uy[j], uz[j], rx[j], ry[j], rz[j]);
+                        nodeAccelerations.Add(na);
+                    }
+                }
+            }
+
+            return nodeAccelerations;
         }
 
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -82,7 +82,6 @@ namespace BH.Adapter.ETABS
 
         private List<NodeAcceleration> ReadNodeAcceleration(List<string> nodeIds)
         {
-            //throw new NotImplementedException("Node Acceleration results is not supported yet!");
 
             List<NodeAcceleration> nodeAccelerations = new List<NodeAcceleration>();
 


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #460 

![GH Script - Success - After Pull Request](https://github.com/user-attachments/assets/56edc653-8db7-4731-a503-4e2e8e0213a4)


![ETABS Outputs - Success](https://github.com/user-attachments/assets/2d992512-be7a-443b-8f5d-b1b2262f58c0)




ETABS Toolkit now can allow to extract joint accelerations outputs from ETABS.


 ### Test files
Grasshopper File
[https://burohappold.sharepoint.com/:u:/s/BHoM/ESMRcVgt7RBDmxfhsz9HF_4BZOKpp9A_JYihkY1BjTNIGw?e=AJjNUE](url)
ETABS File
[https://burohappold.sharepoint.com/:i:/s/BHoM/EfzC47OrWThIof0lXaPvMX0BTg-mcMYKC1zuJkQ4Nais-A?e=uF0gSf](url)



 ### Changelog

- Added ReadNodeAcceleration Method to retrieve Abs Joint Accelerations from ETABS
