### PR TITLE
Extract Mesh VonMises Stresses

### DIFF
--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -295,7 +295,7 @@ namespace BH.Adapter.ETABS
             }
             else
             {
-                Engine.Base.Compute.RecordWarning("Stress extraction is currently only possible at bot and top layers. Please update the MeshResultLayer parameter");
+                Engine.Base.Compute.RecordWarning("Stress extraction is currently only possible at bot and top layers. Please update the MeshResultLayer parameter.");
                 return new List<MeshResult>();
             }
 

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -42,7 +42,6 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.oM.Adapter;
 using BH.oM.Structure.Elements;
-using System.Xml.Linq;
 
 namespace BH.Adapter.ETABS
 {

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -228,9 +228,7 @@ namespace BH.Adapter.ETABS
                 {
                     List<MeshStress> stressTop = new List<MeshStress>();
                     List<MeshStress> stressBot = new List<MeshStress>();
-                    int ret = m_model.Results.AreaStressShell(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm, ref pointElm, ref loadCase, ref stepType, 
-                        ref stepNum, ref s11Top, ref s22Top, ref s12Top, ref sMaxTop, ref sMinTop, ref sAngTop, ref svmTop, ref s11Bot, ref s22Bot, ref s12Bot, ref sMaxBot, ref sMinBot, 
-                        ref sAngBot, ref svmBot, ref s13Avg, ref s23Avg, ref sMaxAvg, ref sAngAvg);
+                    int ret = m_model.Results.AreaStressShell(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm, ref pointElm, ref loadCase, ref stepType, ref stepNum, ref s11Top, ref s22Top, ref s12Top, ref sMaxTop, ref sMinTop, ref sAngTop, ref svmTop, ref s11Bot, ref s22Bot, ref s12Bot, ref sMaxBot, ref sMinBot, ref sAngBot, ref svmBot, ref s13Avg, ref s23Avg, ref sMaxAvg, ref sAngAvg);
 
                     if (ret == 0)
                     {
@@ -239,10 +237,8 @@ namespace BH.Adapter.ETABS
                             int mode;
                             double timeStep;
                             GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
-                            MeshStress mStressTop = new MeshStress(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, MeshResultLayer.Upper, 1, MeshResultSmoothingType.None, 
-                                oM.Geometry.Basis.XY, s11Top[j], s22Top[j], s12Top[j], s13Avg[j], s23Avg[j], sMaxTop[j], sMinTop[j], double.NaN);
-                            MeshStress mStressBot = new MeshStress(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, MeshResultLayer.Lower, 0, MeshResultSmoothingType.None, 
-                                oM.Geometry.Basis.XY, s11Bot[j], s22Bot[j], s12Bot[j], s13Avg[j], s23Avg[j], sMaxBot[j], sMinBot[j], double.NaN);
+                            MeshStress mStressTop = new MeshStress(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, MeshResultLayer.Upper, 1, MeshResultSmoothingType.None, oM.Geometry.Basis.XY, s11Top[j], s22Top[j], s12Top[j], s13Avg[j], s23Avg[j], sMaxTop[j], sMinTop[j], double.NaN);
+                            MeshStress mStressBot = new MeshStress(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, MeshResultLayer.Lower, 0, MeshResultSmoothingType.None, oM.Geometry.Basis.XY, s11Bot[j], s22Bot[j], s12Bot[j], s13Avg[j], s23Avg[j], sMaxBot[j], sMinBot[j], double.NaN);
 
                             stressBot.Add(mStressBot);
                             stressTop.Add(mStressTop);

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -339,14 +339,11 @@ namespace BH.Adapter.ETABS
                             int mode;
                             double timeStep;
 
-                            // Calculate Von Mises Moment
-                            double Mvm = ComputeVonMisesMoment(svmTop[j], svmBot[j], panelThk);
-
                             GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
                             MeshVonMises mStressVMTop = new MeshVonMises(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, 
-                                MeshResultLayer.Upper, 1, MeshResultSmoothingType.None, oM.Geometry.Basis.XY, svmTop[j], fvm[j], Mvm);
+                                MeshResultLayer.Upper, 1, MeshResultSmoothingType.None, oM.Geometry.Basis.XY, svmTop[j], fvm[j], double.NaN);
                             MeshVonMises mStressVMBot = new MeshVonMises(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, 
-                                MeshResultLayer.Lower, 0, MeshResultSmoothingType.None, oM.Geometry.Basis.XY, svmBot[j], fvm[j], Mvm);
+                                MeshResultLayer.Lower, 0, MeshResultSmoothingType.None, oM.Geometry.Basis.XY, svmBot[j], fvm[j], double.NaN);
 
                             stressVMBot.Add(mStressVMBot);
                             stressVMTop.Add(mStressVMTop);
@@ -669,23 +666,12 @@ namespace BH.Adapter.ETABS
 
                 double s = group.Average(x => x.S);
                 double n = group.Average(x => x.N);
-                double m = group.Average(x => x.M);
 
                 smoothenedVMStresses.Add(new MeshVonMises(first.ObjectId, first.NodeId, "", first.ResultCase, first.ModeNumber, first.TimeStep, 
-                                                            first.MeshResultLayer, first.LayerPosition, MeshResultSmoothingType.ByPanel, first.Orientation,s,n,m));
+                                                            first.MeshResultLayer, first.LayerPosition, MeshResultSmoothingType.ByPanel, first.Orientation,s,n,double.NaN));
             }
 
             return smoothenedVMStresses;
-        }
-
-        /***************************************************/
-
-        private double ComputeVonMisesMoment(double svmTop, double svmBot, double thk)
-        {
-            double svmAvg = (svmTop + svmBot) / 2;
-            double vonMisesMoment = ((svmBot - svmAvg) * (thk / 2) * (1 / 2) * (thk - 2 * thk / 2 * 1 / 3)) / 1000;
-
-            return vonMisesMoment;
         }
 
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -63,7 +63,6 @@ namespace BH.Adapter.ETABS
             CheckAndSetUpCases(request);
             List<string> panelIds = CheckGetPanelIds(request);
 
-            
             switch (request.ResultType)
             {
                 case MeshResultType.Forces:
@@ -88,7 +87,6 @@ namespace BH.Adapter.ETABS
 
         private List<MeshResult> ReadMeshForce(List<string> panelIds, MeshResultSmoothingType smoothing)
         {
-
             switch (smoothing)
             {
                 case MeshResultSmoothingType.BySelection:
@@ -131,7 +129,6 @@ namespace BH.Adapter.ETABS
 
             for (int i = 0; i < panelIds.Count; i++)
             {
-
                 List<MeshForce> forces = new List<MeshForce>();
                 
                 int ret = m_model.Results.AreaForceShell(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm,
@@ -143,7 +140,6 @@ namespace BH.Adapter.ETABS
                     int mode;
                     double timeStep;
                     
-
                     if (stepType[j] == "Single Value" || stepNum.Length < j)
                     {
                         mode = 0;
@@ -219,7 +215,6 @@ namespace BH.Adapter.ETABS
 
             List<MeshResult> results = new List<MeshResult>();
 
-
             if (smoothing == MeshResultSmoothingType.ByPanel)
                 Engine.Base.Compute.RecordWarning("Stress values have been smoothed outside the API by averaging all force values in each node");
 
@@ -231,7 +226,6 @@ namespace BH.Adapter.ETABS
 
                 for (int i = 0; i < panelIds.Count; i++)
                 {
-
                     List<MeshStress> stressTop = new List<MeshStress>();
                     List<MeshStress> stressBot = new List<MeshStress>();
                     int ret = m_model.Results.AreaStressShell(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm, ref pointElm, ref loadCase, ref stepType, 
@@ -240,7 +234,6 @@ namespace BH.Adapter.ETABS
 
                     if (ret == 0)
                     {
-
                         for (int j = 0; j < resultCount; j++)
                         {
                             int mode;
@@ -254,7 +247,6 @@ namespace BH.Adapter.ETABS
                             stressBot.Add(mStressBot);
                             stressTop.Add(mStressTop);
                         }
-
 
                         if (smoothing == MeshResultSmoothingType.ByPanel)
                         {
@@ -272,7 +264,6 @@ namespace BH.Adapter.ETABS
                     }
                 }
             }
-
             return results;
         }
 
@@ -313,19 +304,18 @@ namespace BH.Adapter.ETABS
 
             List<MeshResult> results = new List<MeshResult>();
 
-
             if (smoothing == MeshResultSmoothingType.ByPanel)
                 Engine.Base.Compute.RecordWarning("Stress values have been smoothed outside the API by averaging all force values in each node");
 
             foreach (string caseName in cases)
             {
                 m_model.Results.Setup.DeselectAllCasesAndCombosForOutput();
+
                 if (!SetUpCaseOrCombo(caseName))
                     continue;
 
                 for (int i = 0; i < panelIds.Count; i++)
                 {
-
                     List<MeshVonMises> stressVMTop = new List<MeshVonMises>();
                     List<MeshVonMises> stressVMBot = new List<MeshVonMises>();
                     int ret1, ret2, ret3;
@@ -346,10 +336,8 @@ namespace BH.Adapter.ETABS
                     // Get the panel thickness
                     panelThk = GetPanelThickness(panelIds[i]);
 
-
                     if ((ret1 == 0) && (ret2 == 0))
                     {
-
                         for (int j = 0; j < resultCount; j++)
                         {
                             int mode;
@@ -368,7 +356,6 @@ namespace BH.Adapter.ETABS
                             stressVMTop.Add(mStressVMTop);
                         }
 
-
                         if (smoothing == MeshResultSmoothingType.ByPanel)
                         {
                             stressVMTop = SmoothenVonMisesStresses(stressVMTop);
@@ -385,15 +372,10 @@ namespace BH.Adapter.ETABS
                     }
                 }
             }
-
             return results;
 
         }
 
-
-        
-            
-            
         /***************************************************/
 
         //Method atempting to extract results using AreaStressLayered method. API call is currently never returning any results for this.
@@ -414,10 +396,8 @@ namespace BH.Adapter.ETABS
             string[] obj = null;
             string[] elm = null;
             string[] layer = null;
-
             int[] intPtNb = null;
             double[] layerPos = null;
-
             string[] pointElm = null;
             string[] loadCase = null;
             string[] stepType = null;
@@ -429,7 +409,6 @@ namespace BH.Adapter.ETABS
             double[] sMin = null;
             double[] sAng = null;
             double[] svm = null;
-
             double[] s13 = null;
             double[] s23 = null;
             double[] sMaxAvg = null;
@@ -437,10 +416,8 @@ namespace BH.Adapter.ETABS
 
             List<MeshResult> results = new List<MeshResult>();
 
-
             if (smoothing == MeshResultSmoothingType.ByPanel)
                 Engine.Base.Compute.RecordWarning("Stress values have been smoothened outside the API by averaging all force values in each node");
-
 
             foreach (string caseName in cases)
             {
@@ -450,28 +427,20 @@ namespace BH.Adapter.ETABS
 
                 for (int i = 0; i < panelIds.Count; i++)
                 {
-
                     List<MeshStress> stresses = new List<MeshStress>();
                     int ret = m_model.Results.AreaStressShellLayered(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm, ref layer, ref intPtNb, ref layerPos, ref pointElm, ref loadCase, ref stepType, ref stepNum, ref s11, ref s22, ref s12, ref sMax, ref sMin, ref sAng, ref svm, ref s13, ref s23, ref sMaxAvg, ref sAngAvg);
                     
                     if (ret == 0)
                     {
-
                         for (int j = 0; j < resultCount - 1; j++)
                         {
                             int mode;
                             double timeStep;
                             GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
                             MeshStress mStress = new MeshStress(panelIds[i], pointElm[j], elm[j], loadCase[j], mode, timeStep, MeshResultLayer.Arbitrary, layerPos[j], MeshResultSmoothingType.None, oM.Geometry.Basis.XY, s11[j], s22[j], s12[j], s13[j], s23[j], sMax[j], sMin[j], sMaxAvg[j]);
-
-                            stresses.Add(mStress);
-                        }
-
-
-                        if (smoothing == MeshResultSmoothingType.ByPanel)
-                        {
-                            stresses = SmoothenStresses(stresses);
-                        }
+                            stresses.Add(mStress);}
+                        
+                        if (smoothing == MeshResultSmoothingType.ByPanel) stresses = SmoothenStresses(stresses);
 
                         results.AddRange(GroupMeshResults(stresses));
                     }
@@ -497,7 +466,6 @@ namespace BH.Adapter.ETABS
             string[] loadCase = null;
             string[] stepType = null;
             double[] stepNum = null;
-
             double[] ux = null;
             double[] uy = null;
             double[] uz = null;
@@ -509,11 +477,8 @@ namespace BH.Adapter.ETABS
 
             for (int i = 0; i < panelIds.Count; i++)
             {
-
                 List<MeshDisplacement> displacements = new List<MeshDisplacement>();
-
                 HashSet<string> ptNbs = new HashSet<string>();
-
                 int nbELem = 0;
                 string[] elemNames = new string[0];
                 m_model.AreaObj.GetElm(panelIds[i], ref nbELem, ref elemNames);
@@ -642,11 +607,6 @@ namespace BH.Adapter.ETABS
 
         }
 
-
-
-
-
-
         /***************************************************/
 
         private List<MeshForce> SmoothenForces(List<MeshForce> forces)
@@ -706,7 +666,6 @@ namespace BH.Adapter.ETABS
         }
 
         /***************************************************/
-
 
         private List<MeshVonMises> SmoothenVonMisesStresses(List<MeshVonMises> forces)
         {

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -216,7 +216,7 @@ namespace BH.Adapter.ETABS
             List<MeshResult> results = new List<MeshResult>();
 
             if (smoothing == MeshResultSmoothingType.ByPanel)
-                Engine.Base.Compute.RecordWarning("Stress values have been smoothed outside the API by averaging all force values in each node");
+                Engine.Base.Compute.RecordWarning("Stress values have been smoothed outside the API by averaging all force values in each node.");
 
             foreach (string caseName in cases)
             {
@@ -305,7 +305,7 @@ namespace BH.Adapter.ETABS
             List<MeshResult> results = new List<MeshResult>();
 
             if (smoothing == MeshResultSmoothingType.ByPanel)
-                Engine.Base.Compute.RecordWarning("Stress values have been smoothed outside the API by averaging all force values in each node");
+                Engine.Base.Compute.RecordWarning("Stress values have been smoothed outside the API by averaging all force values in each node.");
 
             foreach (string caseName in cases)
             {

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -315,7 +315,6 @@ namespace BH.Adapter.ETABS
                     List<MeshVonMises> stressVMTop = new List<MeshVonMises>();
                     List<MeshVonMises> stressVMBot = new List<MeshVonMises>();
                     int ret1, ret2, ret3;
-                    double panelThk;
 
                     // Extract Von Mises Stresses
                     ret1= m_model.Results.AreaStressShell(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm, ref pointElm, 
@@ -328,9 +327,6 @@ namespace BH.Adapter.ETABS
                         ref f11, ref f22, ref f12, ref fMax, ref fMin, ref fAngle, ref fvm, 
                         ref m11, ref m22, ref m12, ref mMax, ref mMin, ref mAngle, 
                         ref v13, ref v23, ref vMax, ref vAngle);
-
-                    // Get the panel thickness
-                    panelThk = GetPanelThickness(panelIds[i]);
 
                     if ((ret1 == 0) && (ret2 == 0))
                     {
@@ -539,65 +535,6 @@ namespace BH.Adapter.ETABS
             }
           
             return panelIds;
-        }
-
-        /***************************************************/
-
-        private double GetPanelThickness(string panelId)
-        {
-
-            //Utility Variables
-
-            int ret;
-            string areaPropName="";
-
-            eDeckType deckType=eDeckType.Unfilled;
-            eSlabType slabType=eSlabType.Slab;
-            eShellType shellType=eShellType.ShellThin;
-            eWallPropType wallPropType=eWallPropType.Specified;
-            String matProp="";
-            Double thickness=0;
-            int color=0;
-            String notes="", guid="";
-
-            double slabDepth = 0, ribDepth = 0, ribWidthTop = 0, ribWidthBot = 0, ribSpacing = 0, shearThickness = 0;
-            double unitWeight = 0, shearStudDia = 0, shearStudHt = 0, shearStudFu = 0, bending = 0, matAng = 0;
-            double overallDepth = 0, slabThickness = 0, stemWidthTop=0, stemWidthBot=0, ribSpacingDir1=0, ribSpacingDir2=0;
-            int numLayers = 0, ribsParallelTo = 0, shellTypeInt = 0;
-            bool includeDrillingDOF=false;
-            string[] layerNames = null, matProps = null;
-            double[] dist=null, matAngs=null, shellThicknesses =null;
-            int[] myType=null, numIntegrationP=null, s11Type=null, s22Type=null, s12Type=null;
-
-
-            // 1. GET THE PANEL PROPERTY NAME
-
-            ret = m_model.AreaObj.GetProperty(panelId, ref areaPropName);
-
-
-            // 2. GET THE PANEL THICKNESS
-            
-            // Case 1 - Deck SolidSlab
-            if (m_model.PropArea.GetDeckSolidSlab(areaPropName, ref slabDepth, ref shearStudDia, ref shearStudHt, ref shearStudFu) == 0) return slabDepth;
-            // Case 2 - Deck Unfilled
-            if (m_model.PropArea.GetDeckUnfilled(areaPropName, ref ribDepth, ref ribWidthTop, ref ribWidthBot, ref ribSpacing, ref shearThickness, ref unitWeight) == 0) return Math.Round(ribDepth,3);
-            // Case 3 - Deck Filled
-            if (m_model.PropArea.GetDeckFilled(areaPropName, ref slabDepth, ref ribDepth, ref ribWidthTop, ref ribWidthBot, ref ribSpacing, ref shearThickness, ref unitWeight, ref shearStudDia, ref shearStudHt, ref shearStudFu) == 0) return Math.Round(slabDepth, 3);
-            // Case 4 - Deck
-            if (m_model.PropArea.GetDeck(areaPropName, ref deckType, ref shellType, ref matProp, ref thickness, ref color, ref notes, ref guid) == 0) return Math.Round(thickness, 3);
-            // Case 5 - Slab Waffle
-            if (m_model.PropArea.GetSlabWaffle(areaPropName, ref overallDepth, ref slabThickness, ref stemWidthTop, ref stemWidthBot, ref ribSpacingDir1, ref ribSpacingDir2) == 0) return Math.Round(overallDepth, 3);
-            // Case 6 - Slab Ribbed
-            if (m_model.PropArea.GetSlabRibbed(areaPropName, ref overallDepth, ref slabThickness, ref stemWidthTop, ref stemWidthBot, ref ribSpacing, ref ribsParallelTo) == 0) return Math.Round(overallDepth, 3);
-            // Case 7 - Slab
-            if (m_model.PropArea.GetSlab(areaPropName, ref slabType, ref shellType, ref matProp, ref slabThickness, ref color, ref notes, ref guid) == 0) return Math.Round(slabThickness, 3);
-            // Case 8 - Wall
-            if (m_model.PropArea.GetWall(areaPropName, ref wallPropType, ref shellType, ref matProp, ref thickness, ref color, ref notes, ref guid) == 0) return Math.Round(thickness, 3);
-
-            // Case else - No Thickness found...
-            return 0.0;
-
-
         }
 
         /***************************************************/

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -330,10 +330,7 @@ namespace BH.Adapter.ETABS
                     List<MeshVonMises> stressVMTop = new List<MeshVonMises>();
                     List<MeshVonMises> stressVMBot = new List<MeshVonMises>();
                     int ret1, ret2, ret3;
-                    double[] panelThks = null;
-                    double thkPatternSF = 0;
-                    int thkType = 0;
-                    string thkPattern = "";
+                    double panelThk;
 
                     // Extract Von Mises Stresses
                     ret1= m_model.Results.AreaStressShell(panelIds[i], itemTypeElm, ref resultCount, ref obj, ref elm, ref pointElm, 
@@ -347,14 +344,11 @@ namespace BH.Adapter.ETABS
                         ref m11, ref m22, ref m12, ref mMax, ref mMin, ref mAngle, 
                         ref v13, ref v23, ref vMax, ref vAngle);
 
-                    // Get all the thicknesses of the panel layers
-                    ret3=m_model.AreaObj.GetThickness(panelIds[i], ref thkType, ref thkPattern, ref thkPatternSF, ref panelThks);
-
-                    // Compute the overall thickness of the panel
-                    double panelThk = panelThks.Sum();
+                    // Get the panel thickness
+                    panelThk = GetPanelThickness(panelIds[i]);
 
 
-                    if ((ret1 == 0) && (ret2 == 0) && (ret3==0))
+                    if ((ret1 == 0) && (ret2 == 0))
                     {
 
                         for (int j = 0; j < resultCount; j++)
@@ -589,6 +583,70 @@ namespace BH.Adapter.ETABS
           
             return panelIds;
         }
+
+        /***************************************************/
+
+        private double GetPanelThickness(string panelId)
+        {
+
+            //Utility Variables
+
+            int ret;
+            string areaPropName="";
+
+            eDeckType deckType=eDeckType.Unfilled;
+            eSlabType slabType=eSlabType.Slab;
+            eShellType shellType=eShellType.ShellThin;
+            eWallPropType wallPropType=eWallPropType.Specified;
+            String matProp="";
+            Double thickness=0;
+            int color=0;
+            String notes="", guid="";
+
+            double slabDepth = 0, ribDepth = 0, ribWidthTop = 0, ribWidthBot = 0, ribSpacing = 0, shearThickness = 0;
+            double unitWeight = 0, shearStudDia = 0, shearStudHt = 0, shearStudFu = 0, bending = 0, matAng = 0;
+            double overallDepth = 0, slabThickness = 0, stemWidthTop=0, stemWidthBot=0, ribSpacingDir1=0, ribSpacingDir2=0;
+            int numLayers = 0, ribsParallelTo = 0, shellTypeInt = 0;
+            bool includeDrillingDOF=false;
+            string[] layerNames = null, matProps = null;
+            double[] dist=null, matAngs=null, shellThicknesses =null;
+            int[] myType=null, numIntegrationP=null, s11Type=null, s22Type=null, s12Type=null;
+
+
+            // 1. GET THE PANEL PROPERTY NAME
+
+            ret = m_model.AreaObj.GetProperty(panelId, ref areaPropName);
+
+
+            // 2. GET THE PANEL THICKNESS
+            
+            // Case 1 - Deck SolidSlab
+            if (m_model.PropArea.GetDeckSolidSlab(areaPropName, ref slabDepth, ref shearStudDia, ref shearStudHt, ref shearStudFu) == 0) return slabDepth;
+            // Case 2 - Deck Unfilled
+            if (m_model.PropArea.GetDeckUnfilled(areaPropName, ref ribDepth, ref ribWidthTop, ref ribWidthBot, ref ribSpacing, ref shearThickness, ref unitWeight) == 0) return Math.Round(ribDepth,3);
+            // Case 3 - Deck Filled
+            if (m_model.PropArea.GetDeckFilled(areaPropName, ref slabDepth, ref ribDepth, ref ribWidthTop, ref ribWidthBot, ref ribSpacing, ref shearThickness, ref unitWeight, ref shearStudDia, ref shearStudHt, ref shearStudFu) == 0) return Math.Round(slabDepth, 3);
+            // Case 4 - Deck
+            if (m_model.PropArea.GetDeck(areaPropName, ref deckType, ref shellType, ref matProp, ref thickness, ref color, ref notes, ref guid) == 0) return Math.Round(thickness, 3);
+            // Case 5 - Slab Waffle
+            if (m_model.PropArea.GetSlabWaffle(areaPropName, ref overallDepth, ref slabThickness, ref stemWidthTop, ref stemWidthBot, ref ribSpacingDir1, ref ribSpacingDir2) == 0) return Math.Round(overallDepth, 3);
+            // Case 6 - Slab Ribbed
+            if (m_model.PropArea.GetSlabRibbed(areaPropName, ref overallDepth, ref slabThickness, ref stemWidthTop, ref stemWidthBot, ref ribSpacing, ref ribsParallelTo) == 0) return Math.Round(overallDepth, 3);
+            // Case 7 - Slab
+            if (m_model.PropArea.GetSlab(areaPropName, ref slabType, ref shellType, ref matProp, ref slabThickness, ref color, ref notes, ref guid) == 0) return Math.Round(slabThickness, 3);
+            // Case 8 - Wall
+            if (m_model.PropArea.GetWall(areaPropName, ref wallPropType, ref shellType, ref matProp, ref thickness, ref color, ref notes, ref guid) == 0) return Math.Round(thickness, 3);
+
+            // Case else - No Thickness found...
+            return 0.0;
+
+
+        }
+
+
+
+
+
 
         /***************************************************/
 

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -624,9 +624,7 @@ namespace BH.Adapter.ETABS
                 double vx = group.Average(x => x.VX);
                 double vy = group.Average(x => x.VY);
 
-                smoothenedForces.Add(new MeshForce(first.ObjectId, first.NodeId, "", first.ResultCase, first.ModeNumber, first.TimeStep, 
-                                                        first.MeshResultLayer, first.LayerPosition, MeshResultSmoothingType.ByPanel, first.Orientation, 
-                                                        nxx, nyy, nxy, mxx, myy, mxy, vx, vy));
+                smoothenedForces.Add(new MeshForce(first.ObjectId, first.NodeId, "", first.ResultCase, first.ModeNumber, first.TimeStep, first.MeshResultLayer, first.LayerPosition, MeshResultSmoothingType.ByPanel, first.Orientation, nxx, nyy, nxy, mxx, myy, mxy, vx, vy));
             }
 
             return smoothenedForces;
@@ -653,9 +651,7 @@ namespace BH.Adapter.ETABS
                 double pr2 = group.Average(x => x.Principal_2);
                 double pr1_2 = group.Average(x => x.Principal_1_2);
 
-                smoothenedForces.Add(new MeshStress(first.ObjectId, first.NodeId, "", first.ResultCase, first.ModeNumber, first.TimeStep, 
-                                                        first.MeshResultLayer, first.LayerPosition, MeshResultSmoothingType.ByPanel, first.Orientation, 
-                                                        sxx, syy, sxy, txx, tyy, pr1, pr2, pr1_2));
+                smoothenedForces.Add(new MeshStress(first.ObjectId, first.NodeId, "", first.ResultCase, first.ModeNumber, first.TimeStep, first.MeshResultLayer, first.LayerPosition, MeshResultSmoothingType.ByPanel, first.Orientation, sxx, syy, sxy, txx, tyy, pr1, pr2, pr1_2));
             }
 
             return smoothenedForces;

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -73,6 +73,7 @@ namespace BH.Adapter.ETABS
                 case MeshResultType.Stresses:
                     return ReadMeshStress(panelIds, cases, request.Smoothing, request.Layer);
                 case MeshResultType.VonMises:
+                    return ReadMeshVonMises(panelIds, request.Smoothing);
                 default:
                     Engine.Base.Compute.RecordError("Result extraction of type " + request.ResultType + " is not yet supported");
                     return new List<IResult>();

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -330,7 +330,7 @@ namespace BH.Adapter.ETABS
                     List<MeshVonMises> stressVMTop = new List<MeshVonMises>();
                     List<MeshVonMises> stressVMBot = new List<MeshVonMises>();
                     int ret1, ret2, ret3;
-                    double[] panelThks = [];
+                    double[] panelThks = null;
                     double thkPatternSF = 0;
                     int thkType = 0;
                     string thkPattern = "";

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -79,7 +79,6 @@ namespace BH.Adapter.ETABS
         [Description("Creates an adapter to ETABS version 18 or later. For connection to ETABS v17 use the ETABS17Adapter. For connection to ETABS 2016 use the ETABS2016Adapter. Earlier versions not supported.")]
         public ETABSAdapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #endif
-        
         {
             //Initialisation
             AdapterIdFragmentType = typeof(ETABSId);

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -79,6 +79,7 @@ namespace BH.Adapter.ETABS
         [Description("Creates an adapter to ETABS version 18 or later. For connection to ETABS v17 use the ETABS17Adapter. For connection to ETABS 2016 use the ETABS2016Adapter. Earlier versions not supported.")]
         public ETABSAdapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #endif
+        
         {
             //Initialisation
             AdapterIdFragmentType = typeof(ETABSId);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #463 

![SvmBHoMPlots](https://github.com/user-attachments/assets/808baebd-26a0-470b-85b9-d01bc27e83cc)



![SvmGHvsExcelTableCheck](https://github.com/user-attachments/assets/c7a61e8d-ba9a-4083-b4cf-7135c86d8124)












ETABS Toolkit now can allow to extract Shell Von Mises Stress outputs from ETABS.


 ### Test files

Files Folder
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23471-ExtractMeshVonMisesStresses?csf=1&web=1&e=OpP1iW

Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23471-ExtractMeshVonMisesStresses/Test%20Script.gh?csf=1&web=1&e=AFd4Si

ETABS File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23471-ExtractMeshVonMisesStresses/Test%20ETABS%20Model.EDB?csf=1&web=1&e=6fgDcc

Excel File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23471-ExtractMeshVonMisesStresses/Test%20ETABS%20Model.EDB?csf=1&web=1&e=6fgDcc

 ### Changelog

- Added methods ReadMeshVonMises, SmoothenVonMisesStresses and ComputeVonMisesMoment to read/compute Von Mises stresses from etabs shell objects.
- Added utility method GetPanelThickness for getting the thickness of etabs panels
