### PR TITLE
Fix ReadPointDisplacementLoad

### DIFF
--- a/Etabs_Adapter/CRUD/Read/Load.cs
+++ b/Etabs_Adapter/CRUD/Read/Load.cs
@@ -77,6 +77,12 @@ namespace BH.Adapter.ETABS
                 typeCouldBeRead = true;
             }
 
+            if (type.IsAssignableFrom(typeof(PointDisplacement)))
+            {
+                loads.AddRange(ReadPointDisplacementLoad(loadcaseList));
+                typeCouldBeRead = true;
+            }
+
             if (type.IsAssignableFrom(typeof(BarUniformlyDistributedLoad)))
             {
                 loads.AddRange(ReadBarLoad(loadcaseList));


### PR DESCRIPTION
 ### Issues addressed by this PR

 Closes #472 

![Getter_GHScript](https://github.com/user-attachments/assets/4e657a8d-58e0-400f-bf68-029363c98616)



Now pull of point displacement loads works as expected 

 ### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23473-FixGetPointDispLoad/Test%20Script.gh?csf=1&web=1&e=5uSdY4
ETABS File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23473-FixGetPointDispLoad/Test%20Etabs%20Model.EDB?csf=1&web=1&e=aCjHAI



 ### Changelog
- Add missing call to ReadPointDisplacementLoad function within the main Read method