### PR TITLE
Extract Story Drifts

### DIFF
--- a/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
@@ -56,6 +56,9 @@ namespace BH.Adapter.ETABS
                 case GlobalResultType.Reactions:
                     return GetGlobalReactions();
                 case GlobalResultType.ModalDynamics:
+
+                case GlobalResultType.StoryDrifts:
+                    return GetStoryDrifts();
                 default:
                     Engine.Base.Compute.RecordError("Result extraction of type " + request.ResultType + " is not yet supported");
                     return new List<IResult>();

--- a/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
@@ -57,8 +57,8 @@ namespace BH.Adapter.ETABS
                     return GetGlobalReactions();
                 case GlobalResultType.ModalDynamics:
 
-                case GlobalResultType.StoryDrifts:
-                    return GetStoryDrifts();
+                case GlobalResultType.StoreyDrifts:
+                    return GetStoreyDrifts();
                 default:
                     Engine.Base.Compute.RecordError("Result extraction of type " + request.ResultType + " is not yet supported");
                     return new List<IResult>();
@@ -138,18 +138,18 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
-        private List<StoryDrift> GetStoryDrifts()
+        private List<StoreyDrift> GetStoreyDrifts()
         {
-            List<StoryDrift> storyDrifts = new List<StoryDrift>();
+            List<StoreyDrift> storeyDrifts = new List<StoreyDrift>();
 
             int resultCount = 0;
             string[] loadcaseNames = null;
             string[] stepType = null; double[] stepNum = null;
-            string[] storyNames = null; string[] directions = null;
+            string[] storeyNames = null; string[] directions = null;
             double[] drifts = null; string[] labels = null;
             double[] x = null; double[] y= null; double[] z = null;
 
-            m_model.Results.StoryDrifts(ref resultCount, ref storyNames, ref loadcaseNames, ref stepType, ref stepNum, ref directions, ref drifts, ref labels, ref x, ref y, ref z);
+            m_model.Results.StoryDrifts(ref resultCount, ref storeyNames, ref loadcaseNames, ref stepType, ref stepNum, ref directions, ref drifts, ref labels, ref x, ref y, ref z);
 
 
 
@@ -159,12 +159,12 @@ namespace BH.Adapter.ETABS
                 double timeStep;
                 GetStepAndMode(stepType[i], stepNum[i], out timeStep, out mode);
 
-                StoryDrift stDrft = new StoryDrift("", loadcaseNames[i], mode, timeStep, storyNames[i], directions[i], drifts[i]);
+                StoreyDrift stDrft = new StoreyDrift("", loadcaseNames[i], mode, timeStep, storeyNames[i], directions[i], drifts[i]);
 
-                storyDrifts.Add(stDrft);
+                storeyDrifts.Add(stDrft);
             }
 
-            return storyDrifts;
+            return storeyDrifts;
 
         }
 

--- a/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
@@ -135,6 +135,39 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
+        private List<StoryDrift> GetStoryDrifts()
+        {
+            List<StoryDrift> storyDrifts = new List<StoryDrift>();
+
+            int resultCount = 0;
+            string[] loadcaseNames = null;
+            string[] stepType = null; double[] stepNum = null;
+            string[] storyNames = null; string[] directions = null;
+            double[] drifts = null; string[] labels = null;
+            double[] x = null; double[] y= null; double[] z = null;
+
+            m_model.Results.StoryDrifts(ref resultCount, ref storyNames, ref loadcaseNames, ref stepType, ref stepNum, ref directions, ref drifts, ref labels, ref x, ref y, ref z);
+
+
+
+            for (int i = 0; i < resultCount; i++)
+            {
+                int mode;
+                double timeStep;
+                GetStepAndMode(stepType[i], stepNum[i], out timeStep, out mode);
+
+                StoryDrift stDrft = new StoryDrift("", loadcaseNames[i], mode, timeStep, storyNames[i], directions[i], drifts[i]);
+
+                storyDrifts.Add(stDrft);
+            }
+
+            return storyDrifts;
+
+        }
+
+        /***************************************************/
+
+
     }
 }
 

--- a/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
@@ -32,6 +32,7 @@ using BH.oM.Structure.Results;
 using BH.oM.Analytical.Results;
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;
+using BH.oM.Geometry;
 
 namespace BH.Adapter.ETABS
 {
@@ -151,13 +152,30 @@ namespace BH.Adapter.ETABS
 
             m_model.Results.StoryDrifts(ref resultCount, ref storeyNames, ref loadcaseNames, ref stepType, ref stepNum, ref directions, ref drifts, ref labels, ref x, ref y, ref z);
 
+            Vector[] dirVectors = directions.Select(dirStr =>
+                {
+                    switch (dirStr.ToUpper())
+                    {
+                        case "X":
+                            return Vector.XAxis;
+                            break;
+                        case "Y":
+                            return Vector.YAxis;
+                            break;
+                        default:
+                            return Vector.ZAxis;
+                            break;
+                    }
+                }).ToArray();
+
+
             for (int i = 0; i < resultCount; i++)
             {
                 int mode;
                 double timeStep;
                 GetStepAndMode(stepType[i], stepNum[i], out timeStep, out mode);
 
-                StoreyDrift stDrft = new StoreyDrift("", loadcaseNames[i], mode, timeStep, storeyNames[i], directions[i], drifts[i]);
+                StoreyDrift stDrft = new StoreyDrift("", loadcaseNames[i], mode, timeStep, storeyNames[i], dirVectors[i], drifts[i]);
 
                 storeyDrifts.Add(stDrft);
             }

--- a/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/GlobalResults.cs
@@ -151,8 +151,6 @@ namespace BH.Adapter.ETABS
 
             m_model.Results.StoryDrifts(ref resultCount, ref storeyNames, ref loadcaseNames, ref stepType, ref stepNum, ref directions, ref drifts, ref labels, ref x, ref y, ref z);
 
-
-
             for (int i = 0; i < resultCount; i++)
             {
                 int mode;


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1639


### Issues addressed by this PR

 Closes #138 

![GH Script vs ETABS Tables](https://github.com/user-attachments/assets/24c5ba7a-130e-4a47-bd7d-74f3dc466738)

ETABS Toolkit now able to extract Story Drifts from ETABS Model based on input loadcase/loadcombo.

 ### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23477-ExtractStoryDrifts/Test%20Script.gh?csf=1&web=1&e=lrVtVc
ETABS File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23477-ExtractStoryDrifts/Test%20ETABS%20Model.EDB?csf=1&web=1&e=Frkg7n


 ### Changelog

- Added StoryDrift Class to BHoM Structure Global Results
- Added GetStoryDrifts Method to ETABS Toolkit Read Global Results
