### PR TITLE
Get ETABS File Path

### DIFF
--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -49,8 +49,8 @@
     </Reference>
     <Reference Include="Quantities_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Quantities_oM.dll</HintPath>
-	  <Private>False</Private>
-	  <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_oM.dll</HintPath>
@@ -71,6 +71,7 @@
     <Compile Include="Fragments\ShellTypeFragment.cs" />
     <Compile Include="Requests\Enum\PierAndSpandrelResultType.cs" />
     <Compile Include="Requests\PierAndSpandrelForceRequest.cs" />
+    <Compile Include="Results\BarDesign.cs" />
     <Compile Include="Settings\DataBaseSettings.cs" />
     <Compile Include="Settings\EtabsSettings.cs" />
     <Compile Include="Enums\SectionDatabase.cs" />

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -71,7 +71,6 @@
     <Compile Include="Fragments\ShellTypeFragment.cs" />
     <Compile Include="Requests\Enum\PierAndSpandrelResultType.cs" />
     <Compile Include="Requests\PierAndSpandrelForceRequest.cs" />
-    <Compile Include="Results\BarDesign.cs" />
     <Compile Include="Settings\DataBaseSettings.cs" />
     <Compile Include="Settings\EtabsSettings.cs" />
     <Compile Include="Enums\SectionDatabase.cs" />

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -49,6 +49,8 @@
     </Reference>
     <Reference Include="Quantities_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Quantities_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>	  
     </Reference>
     <Reference Include="Structure_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_oM.dll</HintPath>

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -38,7 +38,7 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_oM">
-      <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -49,8 +49,6 @@
     </Reference>
     <Reference Include="Quantities_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Quantities_oM.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_oM.dll</HintPath>

--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -38,7 +38,7 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/Etabs_Adapter/AdapterActions/Execute.cs
+++ b/Etabs_Adapter/AdapterActions/Execute.cs
@@ -83,6 +83,7 @@ namespace BH.Adapter.ETABS
 
         public bool RunCommand(SaveAs command)
         {
+            this.FilePath = command.FileName;
             return m_model.File.Save(command.FileName) == 0;
         }
 
@@ -92,6 +93,7 @@ namespace BH.Adapter.ETABS
         {
             if (System.IO.File.Exists(command.FileName))
             {
+                this.FilePath = command.FileName;
                 bool success = m_model.File.OpenFile(command.FileName) == 0;
                 success &= m_model.SetPresentUnits(eUnits.N_m_C) == 0;
                 return success;

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -59,6 +59,8 @@ namespace BH.Adapter.ETABS
 
         public const string ID = "ETABS_id";
 
+        public string FilePath;
+
         public EtabsSettings EtabsSettings { get; set; } = new EtabsSettings();
 
         /***************************************************/
@@ -137,6 +139,8 @@ namespace BH.Adapter.ETABS
                     else
                         m_model.File.NewBlank();
                 }
+
+                FilePath = m_model.GetModelFilepath();
 
                 LoadSectionDatabaseNames();
             }

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.ETABS
 
         public const string ID = "ETABS_id";
 
-        public string FilePath;
+        public string FilePath { get; }
 
         public EtabsSettings EtabsSettings { get; set; } = new EtabsSettings();
 
@@ -140,7 +140,7 @@ namespace BH.Adapter.ETABS
                         m_model.File.NewBlank();
                 }
 
-                FilePath = m_model.GetModelFilepath();
+                FilePath = m_model.GetModelFilepath()+m_model.GetModelFilename();
 
                 LoadSectionDatabaseNames();
             }

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.ETABS
 
         public const string ID = "ETABS_id";
 
-        public string FilePath { get; }
+        public string FilePath { get; set; }
 
         public EtabsSettings EtabsSettings { get; set; } = new EtabsSettings();
 

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -140,7 +140,7 @@ namespace BH.Adapter.ETABS
                         m_model.File.NewBlank();
                 }
 
-                FilePath = m_model.GetModelFilepath()+m_model.GetModelFilename();
+                FilePath = m_model.GetModelFilename();
 
                 LoadSectionDatabaseNames();
             }


### PR DESCRIPTION
 ### Issues addressed by this PR

 Closes #413 

![GH Script - Canvas View](https://github.com/user-attachments/assets/4dec1393-3c28-44b1-9a8c-1cab3fbe7363)


ETABS Toolkit now allows to retrieve the full filepath of the ETABS Model as a public attribute of the ETABSAdapter class.


 ### Test files
Grasshopper File

ETABS File


 ### Changelog
- Added public and read-only attribute FilePath to the ETABSAdapter Class
- Added assignment of the FilePath attribute in the Constructor of the ETABSAdapter Class
