### PR TITLE
Add Adapter Support for Structure Openings

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Opening.cs
+++ b/Etabs_Adapter/CRUD/Create/Opening.cs
@@ -1,6 +1,6 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/Etabs_Adapter/CRUD/Create/Opening.cs
+++ b/Etabs_Adapter/CRUD/Create/Opening.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.ETABS;
+using BH.oM.Structure.Elements;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Adapters.ETABS;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.oM.Geometry;
+using BH.oM.Analytical.Elements;
+
+
+namespace BH.Adapter.ETABS
+{
+#if Debug16 || Release16
+    public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
+#endif
+    {
+        /***************************************************/
+        /***    Create Methods                           ***/
+        /***************************************************/
+
+        private bool CreateObject(Opening bhOpening)
+        {
+            bool success = true;
+            int retA = 0;
+
+            double mergeTol = 1e-3; //Merging panel points to the mm, same behaviour as the default node comparer
+
+            if (!CheckPropertyError(bhOpening, bhO => bhO.Edges, true))
+                return false;
+
+            for (int i = 0; i < bhOpening.Edges.Count; i++)
+            {
+                if (!CheckPropertyError(bhOpening, bhO => bhO.Edges[i], true))
+                    return false;
+
+                if (!CheckPropertyError(bhOpening, bhO => bhO.Edges[i].Curve, true))
+                    return false;
+            }
+
+            NonLinearEdgesCheck(bhOpening.Edges);
+
+            List<BH.oM.Geometry.Point> boundaryPoints = bhOpening.ControlPoints(true).CullDuplicates(mergeTol);
+
+            int segmentCount = boundaryPoints.Count();
+            double[] x = new double[segmentCount];
+            double[] y = new double[segmentCount];
+            double[] z = new double[segmentCount];
+            for (int i = 0; i < segmentCount; i++)
+            {
+                x[i] = boundaryPoints[i].X;
+                y[i] = boundaryPoints[i].Y;
+                z[i] = boundaryPoints[i].Z;
+            }
+
+            string openingName = GetAdapterId<string>(bhOpening);
+            retA = m_model.AreaObj.AddByCoord(segmentCount, ref x, ref y, ref z, ref openingName, "Default");
+            ETABSId etabsid = new ETABSId();
+            etabsid.Id = openingName;
+
+            //Label and story
+            string label = "";
+            string story = "";
+            string guid = null;
+
+            if (m_model.AreaObj.GetLabelFromName(openingName, ref label, ref story) == 0)
+            {
+                etabsid.Label = label;
+                etabsid.Story = story;
+            }
+
+            if (m_model.AreaObj.GetGUID(openingName, ref guid) == 0)
+                etabsid.PersistentId = guid;
+
+            bhOpening.SetAdapterId(etabsid);
+
+            m_model.AreaObj.SetOpening(openingName, true);
+
+            return success;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Etabs_Adapter/CRUD/Read/Opening.cs
+++ b/Etabs_Adapter/CRUD/Read/Opening.cs
@@ -1,6 +1,6 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -128,3 +128,4 @@ namespace BH.Adapter.ETABS
 
     }
 }
+

--- a/Etabs_Adapter/CRUD/Read/Opening.cs
+++ b/Etabs_Adapter/CRUD/Read/Opening.cs
@@ -103,7 +103,7 @@ namespace BH.Adapter.ETABS
 
         /***************************************************/
 
-        private Polyline GetOpeningPerimeter(string id)
+        private Polyline GetOpeningOutline(string id)
         {
             string[] pName = null;
             int pointCount = 0;

--- a/Etabs_Adapter/CRUD/Read/Opening.cs
+++ b/Etabs_Adapter/CRUD/Read/Opening.cs
@@ -77,7 +77,7 @@ namespace BH.Adapter.ETABS
                 etabsId.Id = id;
 
                 Opening opening = new Opening();
-                Polyline pl = GetOpeningPerimeter(id);
+                Polyline pl = GetOpeningOutline(id);
 
                 opening.Edges = pl.SubParts().Select(x => new Edge { Curve = x }).ToList();
 

--- a/Etabs_Adapter/CRUD/Read/Opening.cs
+++ b/Etabs_Adapter/CRUD/Read/Opening.cs
@@ -1,0 +1,128 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.ETABS;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.SurfaceProperties;
+using BH.Engine.Adapters.ETABS;
+using BH.oM.Geometry;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.ETABS.Elements;
+using BH.Engine.Structure;
+using BH.Engine.Spatial;
+
+
+namespace BH.Adapter.ETABS
+{
+#if Debug16 || Release16
+    public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
+#endif
+    {
+        /***************************************************/
+        /***    Read Methods                             ***/
+        /***************************************************/
+
+        private List<Opening> ReadOpening(List<string> ids = null)
+        {
+
+            List<string> openingNames = new List<string>();
+            List<Opening> openingList = new List<Opening>();
+
+            int nameCount = 0;
+            string[] nameArr = { };
+            m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
+
+
+            bool isOpening = false;
+            openingNames=nameArr.Where(panelName => { m_model.AreaObj.GetOpening(panelName, ref isOpening);
+                                                      return isOpening;}).ToList();
+
+            ids = FilterIds(ids, openingNames);
+
+            foreach (string id in ids)
+            {
+                ETABSId etabsId = new ETABSId();
+                etabsId.Id = id;
+
+                Opening opening = new Opening();
+                Polyline pl = GetOpeningPerimeter(id);
+
+                opening.Edges=pl.SubParts().Select(x => new Edge { Curve = x }).ToList();
+
+                //Label and story
+                string label = "";
+                string story = "";
+                string guid = null;
+                if (m_model.AreaObj.GetLabelFromName(id, ref label, ref story) == 0)
+                {
+                    etabsId.Label = label;
+                    etabsId.Story = story;
+                }
+
+                if (m_model.AreaObj.GetGUID(id, ref guid) == 0)
+                    etabsId.PersistentId = guid;
+
+                opening.SetAdapterId(etabsId);
+                openingList.Add(opening);
+            }
+
+            return openingList;
+        }
+
+        /***************************************************/
+
+        private Polyline GetOpeningPerimeter(string id)
+        {
+            string[] pName = null;
+            int pointCount = 0;
+            double pX1 = 0;
+            double pY1 = 0;
+            double pZ1 = 0;
+            m_model.AreaObj.GetPoints(id, ref pointCount, ref pName);
+            List<Point> pts = new List<Point>();
+            for (int j = 0; j < pointCount; j++)
+            {
+                m_model.PointObj.GetCoordCartesian(pName[j], ref pX1, ref pY1, ref pZ1);
+                pts.Add(new Point() { X = pX1, Y = pY1, Z = pZ1 });
+            }
+            pts.Add(pts[0]);
+
+            Polyline pl = new Polyline() { ControlPoints = pts };
+
+            return pl;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Etabs_Adapter/CRUD/Read/Opening.cs
+++ b/Etabs_Adapter/CRUD/Read/Opening.cs
@@ -64,8 +64,10 @@ namespace BH.Adapter.ETABS
 
 
             bool isOpening = false;
-            openingNames=nameArr.Where(panelName => { m_model.AreaObj.GetOpening(panelName, ref isOpening);
-                                                      return isOpening;}).ToList();
+            openingNames = nameArr.Where(panelName => {
+                m_model.AreaObj.GetOpening(panelName, ref isOpening);
+                return isOpening;
+            }).ToList();
 
             ids = FilterIds(ids, openingNames);
 
@@ -77,7 +79,7 @@ namespace BH.Adapter.ETABS
                 Opening opening = new Opening();
                 Polyline pl = GetOpeningPerimeter(id);
 
-                opening.Edges=pl.SubParts().Select(x => new Edge { Curve = x }).ToList();
+                opening.Edges = pl.SubParts().Select(x => new Edge { Curve = x }).ToList();
 
                 //Label and story
                 string label = "";

--- a/Etabs_Adapter/CRUD/Read/Panel.cs
+++ b/Etabs_Adapter/CRUD/Read/Panel.cs
@@ -63,13 +63,13 @@ namespace BH.Adapter.ETABS
 
             //Remove the Opening Objects from the Panels List
             bool isOpening = false;
-            nameArr.Where(panelName => {
+            List<string> nameList=nameArr.Where(panelName => {
                 m_model.AreaObj.GetOpening(panelName, ref isOpening);
-                return !isOpening;});
+                return !isOpening;}).ToList();
             //Update number of Panels removing Opening Objects from it
-            nameCount = nameArr.Length;
+            nameCount = nameList.Count;
 
-            ids = FilterIds(ids, nameArr);
+            ids = FilterIds(ids, nameList);
 
             foreach (string id in ids)
             {

--- a/Etabs_Adapter/CRUD/Read/Panel.cs
+++ b/Etabs_Adapter/CRUD/Read/Panel.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -152,6 +152,7 @@ namespace BH.Adapter.ETABS
 
     }
 }
+
 
 
 

--- a/Etabs_Adapter/CRUD/Read/_Read.cs
+++ b/Etabs_Adapter/CRUD/Read/_Read.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -190,6 +190,7 @@ namespace BH.Adapter.ETABS
 
     }
 }
+
 
 
 

--- a/Etabs_Adapter/CRUD/Read/_Read.cs
+++ b/Etabs_Adapter/CRUD/Read/_Read.cs
@@ -70,6 +70,8 @@ namespace BH.Adapter.ETABS
                 return ReadMaterial(listIds);
             else if (type == typeof(Panel))
                 return ReadPanel(listIds);
+            else if (type == typeof(Opening))
+                return ReadOpening(listIds);
             else if (type == typeof(ISurfaceProperty) || type.GetInterfaces().Contains(typeof(ISurfaceProperty)))
                 return ReadSurfaceProperty(listIds);
             else if (type == typeof(LoadCombination))

--- a/Etabs_Adapter/CRUD/Read/_Read.cs
+++ b/Etabs_Adapter/CRUD/Read/_Read.cs
@@ -123,6 +123,18 @@ namespace BH.Adapter.ETABS
 
             m_model.SelectObj.GetSelected(ref numItems, ref objectTypes, ref objectIds);
 
+            // Replace Panels' type numbers with Openings' type numbers
+            
+            for (int i=0; i<numItems; i++)
+            {
+                if (objectTypes[i]==5)
+                {
+                    bool isOpening=false;
+                    m_model.AreaObj.GetOpening(objectIds[i], ref isOpening);
+                    if (isOpening) objectTypes[i] = 8;
+                }
+            }
+
             Dictionary<int, List<string>> dict = objectTypes.Distinct().ToDictionary(x => x, x => new List<string>());
 
             for (int i = 0; i < numItems; i++)
@@ -146,6 +158,8 @@ namespace BH.Adapter.ETABS
                         return null;
                     case 7: // Link Object
                         return typeof(RigidLink);
+                    case 8: // Opening Object (not api-native)
+                        return typeof(Opening);
                     default:
                         return null;
                 }

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Convert\ToCSI\Vector.cs" />
     <Compile Include="CRUD\Create\Loadcase.cs" />
     <Compile Include="CRUD\Create\Diaphragm.cs" />
+    <Compile Include="CRUD\Create\Opening.cs" />
     <Compile Include="CRUD\Create\SurfaceProperty.cs" />
     <Compile Include="CRUD\Create\SectionProperty.cs" />
     <Compile Include="CRUD\Create\Panel.cs" />
@@ -365,6 +366,7 @@
     <Compile Include="CRUD\Delete\_Delete.cs" />
     <Compile Include="CRUD\Read\Grid.cs" />
     <Compile Include="CRUD\Read\Loadcase.cs" />
+    <Compile Include="CRUD\Read\Opening.cs" />
     <Compile Include="CRUD\Read\Results\PierAndSpandrelResults.cs" />
     <Compile Include="CRUD\Read\SectionProperty.cs" />
     <Compile Include="CRUD\Read\Results\BarResults.cs" />

--- a/Etabs_Adapter/Types/DependencyTypes.cs
+++ b/Etabs_Adapter/Types/DependencyTypes.cs
@@ -52,6 +52,7 @@ namespace BH.Adapter.ETABS
                 {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node) } },
                 {typeof(ISectionProperty), new List<Type> { typeof(IMaterialFragment) } },
                 {typeof(Panel), new List<Type> { typeof(ISurfaceProperty) } },
+                {typeof(Opening), new List<Type> {typeof(Edge) } },
                 {typeof(ISurfaceProperty), new List<Type> { typeof(IMaterialFragment) } },
                 {typeof(RigidLink), new List<Type> { typeof(Node), typeof(LinkConstraint) } },
                 {typeof(ILoad), new List<Type> {typeof(Loadcase) } },

--- a/Etabs_Adapter/Types/DependencyTypes.cs
+++ b/Etabs_Adapter/Types/DependencyTypes.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -65,6 +65,7 @@ namespace BH.Adapter.ETABS
     }
 
 }
+
 
 
 


### PR DESCRIPTION
### Issues addressed by this PR

 Closes #375 

![GH Script Model View](https://github.com/user-attachments/assets/8794773f-59a5-466a-a74e-06485470853e)

![ETABS Model View 03](https://github.com/user-attachments/assets/b1ae513a-98a6-4e00-8f0d-73818ec40d90)

ETABS Toolkit now allows to push and pull Opening objects.


 ### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23479-AddSupportForStructureOpenings/Test%20Script.gh?csf=1&web=1&e=fdeQlU
ETABS File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23479-AddSupportForStructureOpenings/Test%20ETABS%20Model.EDB?csf=1&web=1&e=xXim64

 ### Changelog
- Added Opening.cs class in Read and Create packages
