### PR TITLE
Fix Issue with Pushing Levels by using PriorityTypes

### DIFF
--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -86,6 +86,7 @@ namespace BH.Adapter.ETABS
             SetupDependencies();
             SetupPriorities();
             SetupComparers();
+            m_AdapterSettings.HandlePriorities = true;
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateNonExisting;
 
 

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -84,6 +84,7 @@ namespace BH.Adapter.ETABS
             AdapterIdFragmentType = typeof(ETABSId);
             BH.Adapter.Modules.Structure.ModuleLoader.LoadModules(this);
             SetupDependencies();
+            SetupPriorities();
             SetupComparers();
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateNonExisting;
 

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Types\Comparer.cs" />
     <Compile Include="Types\DependencyTypes.cs" />
+    <Compile Include="Types\PriorityTypes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ETABS_Engine\ETABS_Engine.csproj">

--- a/Etabs_Adapter/Types/PriorityTypes.cs
+++ b/Etabs_Adapter/Types/PriorityTypes.cs
@@ -1,0 +1,79 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Structure.SurfaceProperties;
+using BH.oM.Structure.Constraints;
+using BH.oM.Structure.Loads;
+using System;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.ETABS;
+using System.Collections.Generic;
+using BH.oM.Spatial.SettingOut;
+
+namespace BH.Adapter.ETABS
+{
+#if Debug16 || Release16
+    public partial class ETABS2016Adapter : BHoMAdapter
+#elif Debug17 || Release17
+   public partial class ETABS17Adapter : BHoMAdapter
+#else
+    public partial class ETABSAdapter : BHoMAdapter
+#endif
+    {
+        /***************************************************/
+        /**** Protected methods                         ****/
+        /***************************************************/
+
+        protected void SetupPriorities()
+        {
+            Type[] types= new Type[]
+            {
+                typeof(Level),
+                typeof(Node),
+                typeof(ISectionProperty),
+                typeof(IMaterialFragment),
+                typeof(Bar),
+                typeof(ISurfaceProperty),
+                typeof(Panel),
+                typeof(RigidLink),
+                typeof(LinkConstraint),
+                typeof(Loadcase),
+                typeof(IElementLoad<Node>),
+                typeof(IElementLoad<Bar>)
+            };
+
+            PriorityTypes = new Queue<Type>(types);
+
+        }
+
+        /***************************************************/
+    }
+
+}
+
+
+
+
+

--- a/Etabs_Adapter/Types/PriorityTypes.cs
+++ b/Etabs_Adapter/Types/PriorityTypes.cs
@@ -48,23 +48,22 @@ namespace BH.Adapter.ETABS
 
         protected void SetupPriorities()
         {
-            Type[] types= new Type[]
-            {
-                typeof(Level),
-                typeof(Node),
-                typeof(ISectionProperty),
-                typeof(IMaterialFragment),
-                typeof(Bar),
-                typeof(ISurfaceProperty),
-                typeof(Panel),
-                typeof(RigidLink),
-                typeof(LinkConstraint),
-                typeof(Loadcase),
-                typeof(IElementLoad<Node>),
-                typeof(IElementLoad<Bar>)
-            };
 
-            PriorityTypes = new Queue<Type>(types);
+            PriorityTypes = new Dictionary<Type, int>
+            {
+                {typeof(Level),0 },
+                {typeof(Node),1 },
+                {typeof(ISectionProperty),2 },
+                {typeof(IMaterialFragment),3 },
+                {typeof(Bar),4 },
+                {typeof(ISurfaceProperty),5 },
+                {typeof(Panel),6 },
+                {typeof(RigidLink),7 },
+                {typeof(LinkConstraint),8 },
+                {typeof(Loadcase),9 },
+                {typeof(IElementLoad<Node>),10 },
+                {typeof(IElementLoad<Bar>),11 }
+            };
 
         }
 

--- a/Etabs_Adapter/Types/PriorityTypes.cs
+++ b/Etabs_Adapter/Types/PriorityTypes.cs
@@ -49,22 +49,10 @@ namespace BH.Adapter.ETABS
         protected void SetupPriorities()
         {
 
-            PriorityTypes = new Dictionary<Type, int>
+            PriorityTypes = new List<Type>
             {
-                {typeof(Level),0 },
-                {typeof(Node),1 },
-                {typeof(ISectionProperty),2 },
-                {typeof(IMaterialFragment),3 },
-                {typeof(Bar),4 },
-                {typeof(ISurfaceProperty),5 },
-                {typeof(Panel),6 },
-                {typeof(RigidLink),7 },
-                {typeof(LinkConstraint),8 },
-                {typeof(Loadcase),9 },
-                {typeof(IElementLoad<Node>),10 },
-                {typeof(IElementLoad<Bar>),11 }
+                {typeof(Level)},
             };
-
         }
 
         /***************************************************/


### PR DESCRIPTION
 ### NOTE: Depends on 
https://github.com/BHoM/BHoM_Adapter/pull/393

 ### Issues addressed by this PR

Closes #435 

![ETABS vs GH View Levels Push_Commented](https://github.com/user-attachments/assets/fb88bdfc-c33e-49d2-80d6-e4534243b410)

ETABS Toolkit now able to push objects and levels together by using priorities on top of dependencies for sorting the objects to push.


 ### Test files
Video Demonstration - Issue
https://burohappold.sharepoint.com/:v:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23480-AddPriorityTypesForPush/Push%20Levels%20Issue.mp4?csf=1&web=1&e=7cEacd
Video Demonstration - Solution
https://burohappold.sharepoint.com/:v:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23480-AddPriorityTypesForPush/Push%20Levels%20Sorted.mp4?csf=1&web=1&e=cDUbje
Json File
https://burohappold.sharepoint.com/sites/BHoM/_layouts/15/download.aspx?UniqueId=aa695dbddee44123b35aecc6843d658a&e=mvnMou
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23480-AddPriorityTypesForPush/Test%20Script.gh?csf=1&web=1&e=Lzfzec
Etabs File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23480-AddPriorityTypesForPush/Test%20ETABS%20Model.EDB?csf=1&web=1&e=lj7JY7


 ### Changelog
- Added class "PriorityTypes"
- Added implementation of HandlePriorities attribute for the ETABS Adapter
