### PR TITLE
Fix Bug when Pushing Bars to ETABS21

### DIFF
--- a/Etabs_Adapter/CRUD/Create/Bar.cs
+++ b/Etabs_Adapter/CRUD/Create/Bar.cs
@@ -155,8 +155,8 @@ namespace BH.Adapter.ETABS
 
             // Avoid following operation if ETABS Version is ETABS21...
             string majorVersion = "";
-            if(this.etabsVersion != null && this.etabsVersion.Contains("."))
-                majorVersion = this.etabsVersion.Split('.')[0];
+            if(this.EtabsVersion != null && this.EtabsVersion.Contains("."))
+                majorVersion = this.EtabsVersion.Split('.')[0];
 
             if (majorVersion != "21") 
             {
@@ -166,6 +166,10 @@ namespace BH.Adapter.ETABS
                     CreatePropertyWarning("Insertion point and perpendicular offset", "Bar", name);
                     ret++;
                 }
+            }
+            else if (bhBar.FindFragment<InsertionPoint>() != null)
+            {
+                CreatePropertyWarning("Insertion point pushing is unsupported for ETABS 21", "Bar", name);
             }
 
             if (bhBar.Release != null && bhBar.Release.StartRelease != null && bhBar.Release.EndRelease != null) 

--- a/Etabs_Adapter/CRUD/Create/Bar.cs
+++ b/Etabs_Adapter/CRUD/Create/Bar.cs
@@ -153,9 +153,13 @@ namespace BH.Adapter.ETABS
                 offset2[2] = offset.End.Y;
             }
 
-
             // Avoid following operation if ETABS Version is ETABS21...
-            if (!this.etabsVersion.Contains("21")) {
+            string majorVersion = "";
+            if(this.etabsVersion != null && this.etabsVersion.Contains("."))
+                majorVersion = this.etabsVersion.Split('.')[0];
+
+            if (majorVersion != "21") 
+            {
                 if (m_model.FrameObj.SetInsertionPoint(name, (int)bhBar.InsertionPoint(), false, 
                     bhBar.ModifyStiffnessInsertionPoint(), ref offset1, ref offset2) != 0)
                 {

--- a/Etabs_Adapter/CRUD/Create/Bar.cs
+++ b/Etabs_Adapter/CRUD/Create/Bar.cs
@@ -153,10 +153,15 @@ namespace BH.Adapter.ETABS
                 offset2[2] = offset.End.Y;
             }
 
-            if (m_model.FrameObj.SetInsertionPoint(name, (int)bhBar.InsertionPoint(), false, bhBar.ModifyStiffnessInsertionPoint(), ref offset1, ref offset2) != 0)
-            {
-                CreatePropertyWarning("Insertion point and perpendicular offset", "Bar", name);
-                ret++;
+
+            // Avoid following operation if ETABS Version is ETABS21...
+            if (!this.etabsVersion.Contains("21")) {
+                if (m_model.FrameObj.SetInsertionPoint(name, (int)bhBar.InsertionPoint(), false, 
+                    bhBar.ModifyStiffnessInsertionPoint(), ref offset1, ref offset2) != 0)
+                {
+                    CreatePropertyWarning("Insertion point and perpendicular offset", "Bar", name);
+                    ret++;
+                }
             }
 
             if (bhBar.Release != null && bhBar.Release.StartRelease != null && bhBar.Release.EndRelease != null) 

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -142,6 +142,12 @@ namespace BH.Adapter.ETABS
                         m_model.File.NewBlank();
                 }
 
+                // Get ETABS Model Version
+                string modelVersion = "";
+                double doubleVer = 0;
+                m_app.SapModel.GetVersion(ref modelVersion, ref doubleVer);
+
+                // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();
 
                 LoadSectionDatabaseNames();

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -145,7 +145,9 @@ namespace BH.Adapter.ETABS
 
                 // Get ETABS Model Version
                 double doubleVer = 0;
-                m_app.SapModel.GetVersion(ref etabsVersion, ref doubleVer);
+                string version = "";
+                m_app.SapModel.GetVersion(ref version, ref doubleVer);
+                this.EtabsVersion = version;
 
                 // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.ETABS
         public const string ID = "ETABS_id";
 
         public string FilePath { get; set; }
-        public string etabsVersion;
+        public string EtabsVersion { get; set; }
 
         public EtabsSettings EtabsSettings { get; set; } = new EtabsSettings();
 

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -60,6 +60,7 @@ namespace BH.Adapter.ETABS
         public const string ID = "ETABS_id";
 
         public string FilePath { get; set; }
+        public string etabsVersion;
 
         public EtabsSettings EtabsSettings { get; set; } = new EtabsSettings();
 
@@ -143,9 +144,8 @@ namespace BH.Adapter.ETABS
                 }
 
                 // Get ETABS Model Version
-                string modelVersion = "";
                 double doubleVer = 0;
-                m_app.SapModel.GetVersion(ref modelVersion, ref doubleVer);
+                m_app.SapModel.GetVersion(ref etabsVersion, ref doubleVer);
 
                 // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #482 

![Bug VS Code Screenshot2](https://github.com/user-attachments/assets/887ca584-21df-4662-b7c9-90619515c334)


![image](https://github.com/user-attachments/assets/6e9c2780-a3de-47e3-b388-7faaa496b948)


ETABS Toolkit now able to push bars to ETABS 21 by skipping not-working API function by checking running ETABS version.

 ### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23487-FixBugPushBarsToETABS21/BHoM%207.3.1%20Test%20-%20Bar%20Object%20Push%20to%20ETABS%2021%201.gh?csf=1&web=1&e=FQ2bKd

ETABS File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23487-FixBugPushBarsToETABS21/Test%20ETABS%20Model.EDB?csf=1&web=1&e=JE5bz2


 ### Changelog

- Added extraction of ETABS Version number as a string in Adapter constructor
- Use of ETABS Version Number in the create() method for bars to prevent api bug from popping up
