### PR TITLE
Implement Adapter_Engine for GetActiveObject

### DIFF
--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -119,7 +119,7 @@ namespace BH.Adapter.ETABS
 
                 if (processes > 0)
                 {
-                    object runningInstance = System.Runtime.InteropServices.Marshal.GetActiveObject(programId);
+                    object runningInstance = Query.GetActiveObject(programId);
 
                     m_app = (cOAPI)runningInstance;
                     m_model = m_app.SapModel;

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -83,6 +83,14 @@ namespace BH.Adapter.ETABS
         public ETABSAdapter(string filePath = "", EtabsSettings etabsSetting = null, bool active = false)
 #endif
         {
+            if (Environment.Version.Major > 4)
+            {
+                BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported in net runtimes above NETFramework due to internal errors in the ETABS API. A fix for this is being worked on.\n" +
+                                                   $"If you are running this Adapter from Grasshopper in Rhino 8, you can change the runtime being used by Rhino to NETFramework. To do this please follow the instructions here: https://www.rhino3d.com/en/docs/guides/netcore/");
+                return;
+            }
+
+
             //Initialisation
             AdapterIdFragmentType = typeof(ETABSId);
             BH.Adapter.Modules.Structure.ModuleLoader.LoadModules(this);
@@ -148,6 +156,15 @@ namespace BH.Adapter.ETABS
                 string version = "";
                 m_app.SapModel.GetVersion(ref version, ref doubleVer);
                 this.EtabsVersion = version;
+
+                if (EtabsVersion != null && EtabsVersion.Split('.').First() == "22")
+                {
+                    BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported to be used with ETABS 22 due to internal errors in the ETABS API. A fix for this is being worked on.");
+                    m_model = null;
+                    m_app = null;
+                    return;
+
+                }
 
                 // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Adapter/pull/398
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #491 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Installer](https://burohappold.sharepoint.com/:f:/s/BHoM/EngdHnX9w_5Jr0c2sk7UwmkBUM7VocNTlrLZjH2NZEYk4A?e=oLkZBp)

As a minimum test for each adapter:
1. Run the adapter in Rhino 8;
2. Push a `Bar`;
3. Run an `Execute` method;
4. Pull a result.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Implemented `GetActiveObject` method from the BHoM_Adapter;
- Adapter does not function in .NET Core environments but can be run in Rhino 8 by changing the .NET environment to Framework: https://www.rhino3d.com/en/docs/guides/netcore/ .

### Additional comments
<!-- As required -->