### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ CSI ETABS 20
 CSI ETABS 21
 
 #### Not supported:
-CSI ETABS 22
+CSI ETABS 22 due to internal failures of the ETABS API. A fix for this is being worked on.
+
+### Net runtime issues
+
+There are currently some internal failures in the ETABS API when called in a NET Core environment. For this reason, running the ETABSAdapter in runtimes above net 4 is disabled.
+
+If you are using the ETABS Adapter with Grasshopper in Rhino 8 you can change the runtime used by Rhino to framework. To do this, please see this link: https://www.rhino3d.com/en/docs/guides/netcore/#to-change-rhino-to-always-use-net-framework
+
+A fix to allow for higher net runtimes is being worked on.
 
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ https://www.csiamerica.com/products/etabs
 
 #### Built and tested:
 CSI ETABS 2016
-
 CSI ETABS 17
+CSI ETABS 18
+CSI ETABS 20
+CSI ETABS 21
 
 #### Build set up, untested:
-CSI ETABS 18
+CSI ETABS 22
 
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CSI ETABS 18
 CSI ETABS 20
 CSI ETABS 21
 
-#### Build set up, untested:
+#### Not supported:
 CSI ETABS 22
 
 


### PR DESCRIPTION
 Closes #493 

Added versions supported up to ETABS 21. 
ETABS 22 marked as not supported at the moment.


 ### Changelog

- Updated Readme.md file with list of currently supported versions of ETABS.

