### PR TITLE
Fix bhom crashing with etabs22

### DIFF
--- a/Etabs_Adapter/AdapterActions/Execute.cs
+++ b/Etabs_Adapter/AdapterActions/Execute.cs
@@ -34,7 +34,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 

--- a/Etabs_Adapter/CRUD/Create/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Create/Loadcase.cs
@@ -32,7 +32,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Create/Material.cs
+++ b/Etabs_Adapter/CRUD/Create/Material.cs
@@ -36,7 +36,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -34,7 +34,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Link.cs
+++ b/Etabs_Adapter/CRUD/Read/Link.cs
@@ -37,7 +37,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Load.cs
+++ b/Etabs_Adapter/CRUD/Read/Load.cs
@@ -40,7 +40,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Loadcase.cs
+++ b/Etabs_Adapter/CRUD/Read/Loadcase.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/Material.cs
+++ b/Etabs_Adapter/CRUD/Read/Material.cs
@@ -34,7 +34,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 using BH.Engine.Adapters.ETABS;
 

--- a/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/BarResults.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Geometry;

--- a/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Geometry;

--- a/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Etabs_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -35,7 +35,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;

--- a/Etabs_Adapter/CRUD/Read/SectionProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SectionProperty.cs
@@ -39,7 +39,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Read/SurfaceProperty.cs
+++ b/Etabs_Adapter/CRUD/Read/SurfaceProperty.cs
@@ -38,7 +38,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/CRUD/Update/Material.cs
+++ b/Etabs_Adapter/CRUD/Update/Material.cs
@@ -32,7 +32,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -37,7 +37,7 @@ using ETABS2016;
 #elif Debug17 || Release17
 using ETABSv17;
 #else
-using CSiAPIv1;
+using ETABSv1;
 #endif
 
 namespace BH.Adapter.ETABS

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -157,14 +157,14 @@ namespace BH.Adapter.ETABS
                 m_app.SapModel.GetVersion(ref version, ref doubleVer);
                 this.EtabsVersion = version;
 
-                if (EtabsVersion != null && EtabsVersion.Split('.').First() == "22")
-                {
-                    BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported to be used with ETABS 22 due to internal errors in the ETABS API. A fix for this is being worked on.");
-                    m_model = null;
-                    m_app = null;
-                    return;
+                //if (EtabsVersion != null && EtabsVersion.Split('.').First() == "22")
+                //{
+                //    BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported to be used with ETABS 22 due to internal errors in the ETABS API. A fix for this is being worked on.");
+                //    m_model = null;
+                //    m_app = null;
+                //    return;
 
-                }
+                //}
 
                 // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -282,6 +282,10 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ETABSv1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=453d728ef24c6f5e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 22\ETABSv1.dll</HintPath>
+    </Reference>
     <Reference Include="ETABSv17, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CSI_ETABSv17_x64.1.0.3\lib\ETABSv17.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
@@ -420,7 +424,7 @@
       xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
       xcopy "$(TargetDir)ETABS2016.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
 xcopy "$(TargetDir)ETABSv17.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
-xcopy "$(TargetDir)CSiAPIv1.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "$(TargetDir)ETABSv1.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### Issues addressed by this PR

 Closes #488

Referencing the CSiAPIv1 assembly when running the BHoM with ETABS 22, the FrameObj object from the ETABS API appears not to work, thus preventing the user from running any operation involving frame objects.

Using the ETABSv1.dll assemby instead (see circled in green below) appears to solve the problem, as long as the ETABS 22 version used is 22.6.0 rather than 22.0.0 (the one currently available on BH software center)

![Modifications_To_ETABSToolkit](https://github.com/user-attachments/assets/b2800c92-625d-4081-a0f5-374933d7316f)

In fact, as we can see below, the method FrameObj.GetNameList(..) now works returning the list of all the names of all the frames within the ETABS model (see below).

![FrameObj_GetNameList_Working](https://github.com/user-attachments/assets/c63a036a-122c-494c-bf3d-a5cdeda26cde)


While the ETABS API functions appear to work based on the changes mentioned above, for some reason, we now get a bug fired by the Dictionary bhomSections in the ReadBar method. Something to be investigated further.
Looking forward to getting any ideas/suggestions on how to tackle this specific issue.

![bhomSections_NotWorking](https://github.com/user-attachments/assets/d50b6718-fd18-4476-8ebe-07ff83aea0a4)


 ### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/Test%20Script.gh?csf=1&web=1&e=bVXdSV
ETABS File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/Test%20ETABS%20Model%20v22.6.0.EDB?csf=1&web=1&e=pr158j

 ### Changelog
- Replaced reference to CSiAPIv1 with reference to ETABSv1 assembly
- Need for ETABS 22.6.0 version as 22.0.0 version appears to be affected by bugs in the FrameObj interface

 ### Additional comments
Issue not completely sorted yet