### PR TITLE
Fix Interoperability Issues with ETABS 22

### DIFF
--- a/ETABS_oM/ETABS_oM.csproj
+++ b/ETABS_oM/ETABS_oM.csproj
@@ -50,7 +50,7 @@
     <Reference Include="Quantities_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Quantities_oM.dll</HintPath>
       <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>	  
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_oM.dll</HintPath>
@@ -67,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enums\EtabsVersion.cs" />
     <Compile Include="Fragments\ETABSId.cs" />
     <Compile Include="Fragments\ShellTypeFragment.cs" />
     <Compile Include="Requests\Enum\PierAndSpandrelResultType.cs" />

--- a/ETABS_oM/Enums/EtabsVersion.cs
+++ b/ETABS_oM/Enums/EtabsVersion.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
@@ -25,33 +25,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Base;
-using BH.oM.Base.Attributes;
-using System.ComponentModel;
 
 namespace BH.oM.Adapters.ETABS
 {
-    public class EtabsSettings : IObject
+    public enum EtabsVersion
     {
-        /***************************************************/
-        /**** Public Properties                         ****/
-        /***************************************************/
-
-        [Description("Sets whether the loads being pushed should overwrite existing loads on the same object within the same loadcase")]
-        public virtual bool ReplaceLoads { get; set; } = false;
-
-        [Description("")]
-        public virtual DatabaseSettings DatabaseSettings { get; set; } = new DatabaseSettings();
-
-        [Description("Sets/gets the version number of the attached ETABS application")]
-        public virtual EtabsVersion EtabsVersion { get; set; } = new EtabsVersion();
-
-        /***************************************************/
+        v18,
+        v20,
+        v21,
+        v22,
     }
 }
-
-
-
-
-
-

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -157,14 +157,14 @@ namespace BH.Adapter.ETABS
                 m_app.SapModel.GetVersion(ref version, ref doubleVer);
                 this.EtabsVersion = version;
 
-                if (EtabsVersion != null && EtabsVersion.Split('.').First() == "22")
-                {
-                    BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported to be used with ETABS 22 due to internal errors in the ETABS API. A fix for this is being worked on.");
-                    m_model = null;
-                    m_app = null;
-                    return;
+                //if (EtabsVersion != null && EtabsVersion.Split('.').First() == "22")
+                //{
+                //    BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported to be used with ETABS 22 due to internal errors in the ETABS API. A fix for this is being worked on.");
+                //    m_model = null;
+                //    m_app = null;
+                //    return;
 
-                }
+                //}
 
                 // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -110,6 +110,28 @@ namespace BH.Adapter.ETABS
 
 #elif Debug17 || Release17
                 string pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 17\ETABS.exe";
+
+#else
+                string pathToETABS = "";
+
+                switch (EtabsSettings.EtabsVersion)
+                {
+                    case oM.Adapters.ETABS.EtabsVersion.v18:
+                        pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 18\ETABS.exe";
+                        break;
+                    case oM.Adapters.ETABS.EtabsVersion.v20:
+                        pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 20\ETABS.exe";
+                        break;
+                    case oM.Adapters.ETABS.EtabsVersion.v21:
+                        pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 21\ETABS.exe";
+                        break;
+                    case oM.Adapters.ETABS.EtabsVersion.v22:
+                        pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 22\ETABS.exe";
+                        break;
+                    default:
+                        pathToETABS = @"C:\Program Files\Computers and Structures\ETABS 22\ETABS.exe";
+                        break;
+                }
 #endif
 
 
@@ -140,7 +162,7 @@ namespace BH.Adapter.ETABS
 #if Debug16 || Release16 || Debug17 || Release17
                     m_app = helper.CreateObject(pathToETABS);
 #else
-                    m_app = helper.CreateObjectProgID(programId); //Starts the latest installed version of ETABS
+                    m_app = helper.CreateObject(pathToETABS);
 #endif
                     m_app.ApplicationStart();
                     m_model = m_app.SapModel;

--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -157,15 +157,6 @@ namespace BH.Adapter.ETABS
                 m_app.SapModel.GetVersion(ref version, ref doubleVer);
                 this.EtabsVersion = version;
 
-                //if (EtabsVersion != null && EtabsVersion.Split('.').First() == "22")
-                //{
-                //    BH.Engine.Base.Compute.RecordError($"The ETABSAdapter is currently not supported to be used with ETABS 22 due to internal errors in the ETABS API. A fix for this is being worked on.");
-                //    m_model = null;
-                //    m_app = null;
-                //    return;
-
-                //}
-
                 // Get ETABS Model FilePath
                 FilePath = m_model.GetModelFilename();
 

--- a/Etabs_Adapter/Etabs_Adapter.csproj
+++ b/Etabs_Adapter/Etabs_Adapter.csproj
@@ -265,7 +265,8 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="CSiAPIv1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=8a93c9e72eabf762, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSiAPIv1.1.0.0\lib\net\CSiAPIv1.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 22\CSiAPIv1.dll</HintPath>
     </Reference>
     <Reference Include="Data_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>


### PR DESCRIPTION
### Issues addressed by this PR

 Closes #488

Referencing the CSiAPIv1 assembly v1.0.0 when running the BHoM with ETABS 22, the BHoM crashes.

Using the CSiAPIv1 assembly provided with all versions of ETABS 22 from 22.0.0 to 22.6.0. also causes problems due to the presence of internal bugs in few methods of the ETABS API.

Going for CSiAPIv1 v2.8.0 assembly (corresponding to ETABS 22.7.0) finally resolves all the problems of compatibility between the BHoM and ETABS 22 apart from one.

When initiating a new instance of ETABS from the ETABS Adapter, the method helper.CreateObjectProgID(..) needs to be replaced with the method helper.CreateObject(..) to make it works.
Since this method requires the path to the ETABS executable to be run, depending on the version of ETABS used by the user, a different filepath string has to be used.

This gets achieved by adding an Enum property to the EtabsSettings Class, allowing the user to specify the version of ETABS they want to use prior to activating the adapter.
With this strategy, the ETABS Toolkit can support all ETABS versions including 22.7.0 

IMPORTANT!: All ETABS 22 versions preceding 22.7.0 are NOT TO BE SUPPORTED as they contain internal bugs in their API methods.


TEST with ETABS 20
<img width="2283" height="965" alt="image" src="https://github.com/user-attachments/assets/b367e39c-7800-4bef-84b0-5119a0b8c1e6" />


TEST with ETABS 21
<img width="2268" height="944" alt="image" src="https://github.com/user-attachments/assets/5eb1c122-a702-47e3-ad74-b8cb6c96c29f" />


TEST with ETABS 22
<img width="2294" height="948" alt="image" src="https://github.com/user-attachments/assets/38b16145-4e4e-4036-849b-3b76f8d3cf0a" />



 ### Test files
Grasshopper Files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/22.7.0/BHoM%20Test%20Scripts?csf=1&web=1&e=VrM1jv
C# Console App
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/22.7.0/C%23%20Test%20App?csf=1&web=1&e=YtZIdn
VBA Test Script
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/22.7.0/VBA%20Test%20Script?csf=1&web=1&e=b8FAub
ETABS Files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/22.7.0/ETABS%20Files?csf=1&web=1&e=xc9fNP
Tests Summary
https://burohappold.sharepoint.com/:p:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23488-FixBHoMCrashingWithETABS22/22.7.0/ETABS%2022.7.0%20Tests%20Summary.pptx?d=w20f835c1091748d5b2074f25a6cb09a6&csf=1&web=1&e=P6MvOs

 ### Changelog
- Replaced reference from CSiAPIv1 v1.0.0 to v2.8.0
- Added EtabsVersion Enum in ETABS_OM and added it as property of the EtabsSettings Class
- Added switch case statement in the ETABS Adapter class to determine which executable filepath to use depending on the etabs version chosen by the user.
