### PR TITLE
Add point spring properties on node push and support updates (#533)

### DIFF
--- a/ETABS_Toolkit.sln
+++ b/ETABS_Toolkit.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34511.84

--- a/Etabs_Adapter/CRUD/Create/Node.cs
+++ b/Etabs_Adapter/CRUD/Create/Node.cs
@@ -27,6 +27,7 @@ using BH.Engine.Structure;
 using BH.oM.Adapters.ETABS;
 using BH.oM.Analytical.Elements;
 using BH.oM.Geometry;
+using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Elements;
 using System;
 using System.Collections.Generic;
@@ -88,19 +89,33 @@ namespace BH.Adapter.ETABS
 
         private bool SetObject(Node bhNode, string name)
         {
-            if (bhNode.Support != null)
-            {
-                bool[] restraint = new bool[6];
-                double[] spring = new double[6];
+            // Defaults release the node Ux, Uy & Uz fixed, rotations free.
+            // Spring stiffness defaults to zero for all translations and rotations.
+            bool[] restraint = new bool[6] { true, true, true, false, false, false };
+            double[] spring = new double[6];
 
+            if (bhNode.Support != null)
                 bhNode.Support.ToCSI(ref restraint, ref spring);
 
-                if (m_model.PointObj.SetRestraint(name, ref restraint) == 0) { }
+            if (m_model.PointObj.SetRestraint(name, ref restraint) == 0) { }
+            else
+            {
+                CreatePropertyWarning("Node Restraint", "Node", name);
+            }
+
+            // If any stiffness is applied, a spring property is created and assigned; otherwise any existing spring is cleared.
+            bool hasStiffness = spring.Any(x => x != 0);
+            if (hasStiffness)
+            {
+                string propName = bhNode.Support.DescriptionOrName();
+
+                if (m_model.PropPointSpring.SetPointSpringProp(propName, 1, ref spring) == 0) { }
                 else
                 {
-                    CreatePropertyWarning("Node Restraint", "Node", name);
+                    CreatePropertyWarning("Node Spring", "Node", propName);
                 }
-                if (m_model.PointObj.SetSpring(name, ref spring) == 0) { }
+
+                if (m_model.PointObj.SetSpringAssignment(name, propName) == 0) { }
                 else
                 {
                     CreatePropertyWarning("Node Spring", "Node", name);

--- a/Etabs_Adapter/CRUD/Read/Node.cs
+++ b/Etabs_Adapter/CRUD/Read/Node.cs
@@ -73,6 +73,12 @@ namespace BH.Adapter.ETABS
 
                 Constraint6DOF support = GetConstraint6DOF(restraint, spring);
 
+                // Capture the assigned point spring property name so it round-trips on a pull -> push.
+                // A "None"/blank result means no spring is assigned, so the support name is left blank.
+                string springProp = null;
+                if (m_model.PointObj.GetSpringAssignment(id, ref springProp) == 0 && !string.IsNullOrEmpty(springProp) && springProp != "None")
+                    support.Name = springProp;
+
                 string bhomName = GetBhomNameFromEtabsId(id);
 
                 Node bhNode = new Node { Name = bhomName, Position = new oM.Geometry.Point() { X = x, Y = y, Z = z }, Support = support };

--- a/Etabs_Adapter/CRUD/Update/Node.cs
+++ b/Etabs_Adapter/CRUD/Update/Node.cs
@@ -80,6 +80,8 @@ namespace BH.Adapter.ETABS
             {
                 string name = GetAdapterId<string>(bhNode);                                    // θ(1)
                 success = UpdatePosition(name, comparer, bhNode);                              // θ(1)
+                // Update support before the name change below, as UpdateUniqueName renames the point.
+                success = UpdateSupport(name, bhNode);                                         // θ(1)
                 success = UpdateUniqueName(bhNode);                                            // θ(1)
             }
 
@@ -160,6 +162,64 @@ namespace BH.Adapter.ETABS
 
                 return true;
             }
+
+        /***************************************************/
+
+        // Updates the restraint and spring assignments on an existing point. Only the assignments
+        // are touched here; the spring is referenced by name and its stiffness is never modified -
+        // defining or modifying spring properties is handled by the spring property feature.
+        private bool UpdateSupport(string name, Node bhNode)
+        {
+            // Default support matches ETABS' default for a new point: Ux, Uy, Uz fixed, rotations free,
+            // and no spring stiffness. A null Support keeps these defaults (and the spring is cleared below).
+            bool[] restraint = new bool[6] { true, true, true, false, false, false };
+            double[] spring = new double[6];
+
+            if (bhNode.Support != null)
+            {
+                bhNode.Support.ToCSI(ref restraint, ref spring);
+
+            }
+
+            // Restraints always reflect the support (SetRestraint overwrites, setting and releasing DOFs).
+            if (m_model.PointObj.SetRestraint(name, ref restraint) != 0)
+            {
+                CreatePropertyWarning("Node Restraint", "Node", name);
+            }
+
+            // The spring is assigned by property name; its stiffness is never modified here.
+            // A null Support (no support) clears any spring assignment on the point.
+            string propName = bhNode.Support == null ? null : bhNode.Support.Name;
+
+            if (String.IsNullOrEmpty(propName))
+            {
+                if (m_model.PointObj.DeleteSpring(name) == 0)
+                {
+                    return true;
+                }
+                else
+                {
+                    CreatePropertyWarning("Node Spring", "Node", name);
+                    return false;
+                }
+            }
+
+            // Otherwise only assign a property that already exists; if not found, leave the current assignment and warn.
+            int numberNames = 0;
+            string[] propNames = null;
+            bool propExists = m_model.PropPointSpring.GetNameList(ref numberNames, ref propNames) == 0 && propNames != null && propNames.Contains(propName);
+
+            if (!propExists)
+            {
+                Engine.Base.Compute.RecordWarning($"Spring property '{propName}' has not been created in ETABS yet; the spring assignment on node '{name}' was left unchanged.");
+                return true;
+            }
+
+            if (m_model.PointObj.SetSpringAssignment(name, propName) != 0)
+                CreatePropertyWarning("Node Spring", "Node", name);
+
+            return true;
+        }
 
         /***************************************************/
 


### PR DESCRIPTION
- Push a node's spring as a named point spring property (SetPointSpringProp + SetSpringAssignment), named from the Constraint6DOF via DescriptionOrName

- Default a supportless node to ETABS' default restraint (Ux/Uy/Uz fixed, rotations free)

- Add UpdateSupport so restraints and spring assignments are updated on existing nodes, not just on create

- On update, assign only spring properties that already exist (warn if missing) and clear the spring when no support is set

- Read the assigned spring property name into Support.Name so a spring round-trips on pull -> push

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
