### PR TITLE
Expand reference to resolve conflict

### DIFF
--- a/Etabs_Adapter/ETABSAdapter.cs
+++ b/Etabs_Adapter/ETABSAdapter.cs
@@ -148,7 +148,7 @@ namespace BH.Adapter.ETABS
 
                 if (processes > 0)
                 {
-                    object runningInstance = Query.GetActiveObject(programId);
+                    object runningInstance = BH.Engine.Adapter.Query.GetActiveObject(programId);
 
                     m_app = (cOAPI)runningInstance;
                     m_model = m_app.SapModel;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #545 

 <!-- Add short description of what has been fixed -->
Expanded single Query reference to its full path to resolve conflict between Adapter.Query() & Units.Query(). New Units.Query() method added in Localisation_Toolkit introduces this conflict. 

https://github.com/BHoM/Localisation_Toolkit/pull/181

`object runningInstance = Query.GetActiveObject(programId);`

now reads

`object runningInstance = BH.Engine.Adapter.Query.GetActiveObject(programId);`

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/ETABS_Toolkit/%23546-ExpandReferenceToResolveConflict?d=we8cfb29e1da74b90bd6d02b4414afd53&csf=1&web=1&e=sYDoi8


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
